### PR TITLE
Setup Dockerfile from google's node image

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -1,0 +1,27 @@
+# Use gcloud nodejs image.
+FROM launcher.gcr.io/google/nodejs
+
+# Set working directory.
+WORKDIR /usr/src/app/
+
+# Copy application info.
+COPY package.json .
+COPY package-lock.json .
+
+# Install dependencies.
+RUN npm install
+
+# Install serve as a global.
+RUN npm install -g serve
+
+# Make default hosting port available.
+EXPOSE 8080
+
+# Sets the serve command as the container's main instruction.
+CMD ["serve", "-s", "build"]
+
+# Copy remaining application code.
+COPY . .
+
+# Build the static site.
+RUN npm run build


### PR DESCRIPTION
Simple dockerfile built from google's nodejs image.

Usage:
`docker build --tag volportal:0.5 .` (builds the image)
`docker run --publish 80:8080 --detach --name vp volportal:0.5` (runs the built image in the background with label "vp")
`docker stop vp` (stops the process gracefully)
`docker rm vp` (removes the image from the active process list)