### PR TITLE
  split AE services & set up api as /api/ route 

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,7 +1,6 @@
 from typing import List, Optional
 
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 
 from models import Initiative, VolunteerRole, VolunteerEvent
 from fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_initiatives_list, generate_fake_volunteer_events_list \
@@ -14,46 +13,36 @@ logging.basicConfig(level=logging.DEBUG)
 
 app = FastAPI()
 
-origins = ['*']
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-
 hf_db = DataSource(data_source_type=DataSourceType.MYSQL,
         address=generate_hf_mysql_db_address('35.188.204.248','airtable_database','no_pii','humanity-forward_hf-db1-mysql_no_pii'))
 initiatives_dataset = Dataset(data_source = hf_db, dataset_key='initiatives', primary_key='id', linked_model=Initiative, model_key_map=hf_initiatives)
 events_dataset = Dataset(data_source = hf_db, dataset_key='events', primary_key='id', linked_model=VolunteerEvent, model_key_map=hf_events)
 roles_dataset = Dataset(data_source = hf_db, dataset_key='volunteer_openings', primary_key='id', linked_model=VolunteerRole, model_key_map=hf_volunteer_openings)
 
-@app.get("/", response_model=str)
+@app.get("/api/", response_model=str)
 def root() -> str:
     return "Hello from the Humanity Forward Volunteer Portal Dev Team"
 
-@app.get("/volunteer_roles/", response_model=List[VolunteerRole])
+@app.get("/api/volunteer_roles/", response_model=List[VolunteerRole])
 def get_all_volunteer_roles(fake_data: bool = False) -> List[VolunteerRole]:
     return roles_dataset.get_linked_model_objects() if not fake_data else generate_fake_volunteer_roles_list()
 
-@app.get("/volunteer_roles/{role_external_id}", response_model=VolunteerRole)
+@app.get("/api/volunteer_roles/{role_external_id}", response_model=VolunteerRole)
 def get_volunteer_role_by_external_id(role_external_id, fake_data: bool = False) -> Optional[VolunteerRole]:
     return roles_dataset.get_linked_model_object_for_primary_key(role_external_id) if not fake_data else generate_fake_volunteer_role()
 
-@app.get("/volunteer_events/", response_model=List[VolunteerEvent])
+@app.get("/api/volunteer_events/", response_model=List[VolunteerEvent])
 def get_all_volunteer_events(fake_data: bool = False) -> List[VolunteerEvent]:
     return events_dataset.get_linked_model_objects() if not fake_data else generate_fake_volunteer_events_list()
 
-@app.get("/volunteer_events/{event_external_id}", response_model=VolunteerEvent)
+@app.get("/api/volunteer_events/{event_external_id}", response_model=VolunteerEvent)
 def get_volunteer_event_by_external_id(event_external_id, fake_data: bool = False) -> Optional[VolunteerEvent]:
     return events_dataset.get_linked_model_object_for_primary_key(event_external_id) if not fake_data else generate_fake_volunteer_event()
 
-@app.get("/initiatives/", response_model=List[Initiative])
+@app.get("/api/initiatives/", response_model=List[Initiative])
 def get_all_initiatives(fake_data: bool = False) -> List[Initiative]:
     return initiatives_dataset.get_linked_model_objects() if not fake_data else generate_fake_initiatives_list()
 
-@app.get("/initiatives/{initiative_external_id}", response_model=Initiative)
+@app.get("/api/initiatives/{initiative_external_id}", response_model=Initiative)
 def get_initiative_by_external_id(initiative_external_id, fake_data: bool = False) -> List[Initiative]:
     return initiatives_dataset.get_linked_model_object_for_primary_key(initiative_external_id) if not fake_data else generate_fake_initiative() # type: ignore

--- a/api/app-staging.yaml
+++ b/api/app-staging.yaml
@@ -1,0 +1,4 @@
+runtime: python38
+entrypoint: gunicorn api:app -w 4 -k uvicorn.workers.UvicornWorker
+service: volunteer-portal-api-staging
+instance_class: F4  

--- a/api/deploy-staging-app.sh
+++ b/api/deploy-staging-app.sh
@@ -2,7 +2,7 @@
 
 branch_name=$(git symbolic-ref --short -q HEAD)
 if [ "$branch_name" = "staging" ]; then
-    gcloud app deploy --quiet --version staging --no-promote app.yaml
+    gcloud app deploy --quiet app-staging.yaml
 else
     echo "Please deploy the staging api from the staging branch only"
 fi

--- a/client/app-staging.yaml
+++ b/client/app-staging.yaml
@@ -1,0 +1,14 @@
+runtime: nodejs12
+service: volunteer-portal-client-staging
+handlers:
+ - url: /
+   static_files: build/index.html
+   upload: build/index.html
+
+ - url: /(favicon.ico|manifest.json|static.*)
+   static_files: build/\1
+   upload: build/(.*)
+
+ - url: .*
+   static_files: build/index.html
+   upload: build/index.html

--- a/client/deploy-staging-client.sh
+++ b/client/deploy-staging-client.sh
@@ -4,7 +4,7 @@ branch_name=$(git symbolic-ref --short -q HEAD)
 if [ "$branch_name" = "staging" ]; then
     npm ci
     npm run build
-    gcloud app deploy --quiet --version staging --no-promote app.yaml
+    gcloud app deploy --quiet app-staging.yaml
 else
     echo "Please deploy the staging client from the staging branch only"
 fi

--- a/client/package.json
+++ b/client/package.json
@@ -48,5 +48,4 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5"
   },
-  "proxy": "http://localhost:8000"
 }

--- a/client/src/components/Header.js
+++ b/client/src/components/Header.js
@@ -11,7 +11,7 @@ import HFLogo from '../assets/HF-RR-long-logo.png';
  */
 function Header() {
 
-  fetch('/initiatives?fake_date=true')
+  fetch('/api/initiatives?fake_date=true')
     .then((response) => response.json())
     .then(function(initiatives_data) {
       let initiatives = [];

--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -1,5 +1,10 @@
 dispatch:
   - url: "volunteers.movehumanityforward.com/*"
     service: volunteer-portal-client
-  - url: "api.volunteers.movehumanityforward.com/*"
+  - url: "volunteers.movehumanityforward.com/api/*"
     service: volunteer-portal-api
+
+  - url: "vol-dev.movehumanityforward.com/api/*"
+    service: volunteer-portal-api-staging
+  - url: "vol-dev.movehumanityforward.com/*"
+    service: volunteer-portal-client-staging


### PR DESCRIPTION
Splitting the app engine services into their own services instead of versions so we can set the api is a routes within the same domain to avoid cors complications

removed old cors stuff

@trippersham I left in the testing fetch in the headers file so you and others can verify it's working