### PR TITLE
API allows requests from all origins, client proxies to api in local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,11 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 ### API
 
+Running the API locally requires connecting to HF's databases. Make sure you have been given the correct permissions in GCP and have [authenticated through the GCP CLI](https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_user_account)
+
 In the _api_ directory you can manage dependencies with conda or virtualenv run:
 
-#### `conda create --name dev-env python=3.8 pip`
+#### `conda create --name dev-env -f environment.yml`
 or
 #### `virtualenv dev-env --python=/usr/bin/python3.8`
 
@@ -72,12 +74,12 @@ or
 Activates the virtual environment that the dependencies were installed in to enable you to run the API. This command must be run in a terminal session before running the below commands.
 
 #### `pip install -r requirements.txt`
-This installs the dependencies for the API. This deviates from the standard Conda way of doing things with an `environment.yaml` file, but as long as the `conda create` command above is run with pip at the end, pip packages installed while the environment is active will be local to the environment and won't affect system wide packages.
+If you created your virtual environment using `conda create` then this has already been done for you (and you can always reinstall dependencies by running `conda env update` or `pip install -r requirements.txt` from within the conda virtual environment). If you created your virtual environment using `virtualenv` then this required step installs the dependencies for the API.
 
 #### `uvicorn api:app --app-dir . --reload`
 
 Runs the app in the development mode.<br />
-Open [http://localhost:8000](http://localhost:8000/redoc) to view the API docs in the browser.
+Open [http://localhost:8000/redoc](http://localhost:8000/redoc) to view the API docs in the browser.
 
 #### `mypy .`
 Runs linting which validates Python static type hints/annotations

--- a/api/api.py
+++ b/api/api.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from models import Initiative, VolunteerRole, VolunteerEvent
 from fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_initiatives_list, generate_fake_volunteer_events_list \
@@ -12,6 +13,16 @@ import logging
 logging.basicConfig(level=logging.DEBUG)
 
 app = FastAPI()
+
+origins = ['*']
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 hf_db = DataSource(data_source_type=DataSourceType.MYSQL,
         address=generate_hf_mysql_db_address('35.188.204.248','airtable_database','no_pii','humanity-forward_hf-db1-mysql_no_pii'))

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -48,7 +48,7 @@ def test_create_model_error():
 
 def test_get_initiatives_api():
     # because Initiatives contain VolunteerEvents and VolunteerRoles, this will test field validations on all three models
-    response = client.get('/initiatives')
+    response = client.get('api/initiatives')
     assert response.status_code == 200
 
     initiatives = [Initiative(**initiative_kwargs) for initiative_kwargs in response.json()]

--- a/client/package.json
+++ b/client/package.json
@@ -47,5 +47,6 @@
   "devDependencies": {
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5"
-  }
+  },
+  "proxy": "http://localhost:8000"
 }


### PR DESCRIPTION
This is another quick fix until we move back to a `api.*.movehumanityforward` pattern and use env vars on the client to point to the right API url