### PR TITLE
make initiative buttons conditional on events, roles, and details url

### DIFF
--- a/client/src/components/InitiativeDetail.js
+++ b/client/src/components/InitiativeDetail.js
@@ -164,6 +164,15 @@ function InitiativeDetail(props) {
           currRow = [];
         }
       }
+      var button = null;
+      if (detail['details_url']) {
+        button = (
+          <a href={detail['details_url']}>
+            <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
+              Learn more
+            </Button>
+          </a>);
+      }
       return (
         <>
           <Col
@@ -176,6 +185,9 @@ function InitiativeDetail(props) {
             <h2 className="header-3-section-lead">Initiative:</h2>
             <h2 className="header-3-section-breaker">{detail['title']}</h2>
             <p>{detail['content']}</p>
+            <div className="text-center mt-4 mb-4">
+              {button}
+            </div>
           </Col>
           {evts.length ? (
             <>

--- a/client/src/components/InitiativeDetail.js
+++ b/client/src/components/InitiativeDetail.js
@@ -117,7 +117,7 @@ function InitiativeDetail(props) {
           </Col>
         );
 
-        if (i % 2 === 1 || detail['events'].length === 1) {
+        if (i % 2 === 1 || detail['events'].length - 1 === i) {
           evts.push(<Row>{currRow}</Row>);
           currRow = [];
         }
@@ -131,7 +131,7 @@ function InitiativeDetail(props) {
         const button_text =
           role['role_type'] === 'Requires Application'
             ? 'Apply Here'
-            : 'Tell me more!';
+            : 'Learn More';
 
         currRow.push(
           <Col
@@ -159,7 +159,7 @@ function InitiativeDetail(props) {
           </Col>
         );
 
-        if (i % 2 === 1 || detail['roles'].length === 1) {
+        if (i % 2 === 1 || detail['roles'].length - 1 === i) {
           roles.push(<Row key={`role-row-${i}`}>{currRow}</Row>);
           currRow = [];
         }
@@ -169,7 +169,7 @@ function InitiativeDetail(props) {
         button = (
           <a href={detail['details_url']}>
             <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
-              Learn more
+              Learn More
             </Button>
           </a>);
       }

--- a/client/src/components/Initiatives.js
+++ b/client/src/components/Initiatives.js
@@ -66,7 +66,7 @@ function Initiatives() {
       button = (
         <a href={initiative['details_url']}>
           <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
-            Learn more
+            Learn More
           </Button>
         </a>);
     }
@@ -80,8 +80,8 @@ function Initiatives() {
         key={initiative['initiative_external_id']}
       >
         <h2 className="header-3-section-lead">Initiative {i + 1}:</h2>
-        <h2 className="header-3-section-breaker">{initiatives[i]['title']}</h2>
-        <p>{initiatives[i]['content']}</p>
+        <h2 className="header-3-section-breaker">{initiative['title']}</h2>
+        <p>{initiative['content']}</p>
         <div className="text-center mt-4 mb-4">
           {button}
         </div>

--- a/client/src/components/Initiatives.js
+++ b/client/src/components/Initiatives.js
@@ -52,23 +52,38 @@ function Initiatives() {
   }
   const cards = [];
   for (var i = 0; i < initiatives.length; i++) {
+    const initiative = initiatives[i];
+    console.log(initiative);
+    var button = null;
+    if (initiative['roles'].length > 0 || initiative['events'].length > 0) {
+      button = (
+        <Link to={'/initiatives/' + initiative['initiative_external_id']}>
+          <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
+            View Events & Roles
+          </Button>
+        </Link>);
+    } else if (initiative['details_url']) {
+      button = (
+        <a href={initiative['details_url']}>
+          <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
+            Learn more
+          </Button>
+        </a>);
+    }
+
     cards.push(
       <Col
         xs={12}
         lg={9}
         xl={6}
         className="shadow-card"
-        key={initiatives[i]['initiative_external_id']}
+        key={initiative['initiative_external_id']}
       >
         <h2 className="header-3-section-lead">Initiative {i + 1}:</h2>
         <h2 className="header-3-section-breaker">{initiatives[i]['title']}</h2>
         <p>{initiatives[i]['content']}</p>
         <div className="text-center mt-4 mb-4">
-          <Link to={'/initiatives/' + initiatives[i]['initiative_external_id']}>
-            <Button variant="outline-info" style={{ padding: '.35rem 1.5rem' }}>
-              View Events &amp; Roles
-            </Button>
-          </Link>
+          {button}
         </div>
       </Col>
     );


### PR DESCRIPTION
make initiative buttons conditional on events, roles, and details url.

A button will not show up if there are no events, no roles and no details link. If there is only a details link for an initiative the button will read "learn more" and link to that url.

If there are all 3 events, roles, and detail links, the button will point to the initiatives page and the details link will be displayed on the top card in that page. This probably needs some UX attention, but I think it's a definite improvement off of what is there now.

![image](https://user-images.githubusercontent.com/8518434/99002617-8dd1fe80-24f1-11eb-9b63-cb7b4143dfd7.png)
(in this card we can now remove the inline (non-hyperlinked) link

![image](https://user-images.githubusercontent.com/8518434/99002706-b5c16200-24f1-11eb-9df0-b4013b669fd5.png)
