### PR TITLE
Docker Dev env tweaks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,13 +23,11 @@ services:
 
   client:
     build: ./client
-    command: npm run start
+    command: npm run client
     depends_on:
     - api
     environment:
     - "DANGEROUSLY_DISABLE_HOST_CHECK=true"
-    ports:
-    - 8080:8080
     volumes:
     - ./client:/client
     - client_node_modules:/client/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,8 @@ services:
     - api
     environment:
     - "DANGEROUSLY_DISABLE_HOST_CHECK=true"
+    ports:
+    - 8080:8080
     volumes:
     - ./client:/client
     - client_node_modules:/client/node_modules


### PR DESCRIPTION
Change npm "start" to "client" to allow for hot reloading. when we set up our docker for different environments, we'll use "npm run start" to use the optimized client in build
  
~~Remove the client 8080 port to avoid confusion (8080 port version
doesnt forward to the backend)~~