### PR TITLE
Fix bug where node_modules wouldnt actually update

### DIFF
--- a/client/Dockerfile
+++ b/client/Dockerfile
@@ -7,6 +7,6 @@ WORKDIR /client
 
 COPY . ./
 
+ENV NODE_ENV development
 RUN rm -rf node_modules \
-    && npm install -g serve \
-    && NODE_ENV=development npm install --quiet
+    && npm install --quiet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     - 8080:8080
     volumes:
     - ./client:/client
-    - client_node_modules:/client/node_modules
+    - /client/node_modules
 
   # Proxy allows the client app to access the API on the same host
   # This avoids cross-domain issues.
@@ -37,7 +37,3 @@ services:
     - ./nginx:/etc/nginx/conf.d
     ports:
     - 8000:80
-
-
-volumes:
-  client_node_modules:


### PR DESCRIPTION
## Summary
- Noticed that new npm packages that were installed inside the client shell weren't showing up inside `node_modules`, even after rebuilding the image with `make recreate-client`. Not sure of the reason behind mounting node_modules to the outer `client_node_modules`, but rm'ing that fixes it.

  see: https://stackoverflow.com/a/32785014

- NODE_ENV was still set to `production` in the shell.
- rm unnecessary global `serve` install. Its already referenced in package.json. `npm start` works fine without it.

## Test Plan
- install new package, run `make shell-client`, make sure that package is inside `node_modules`. visit localhost:8000, stuff works
- `make recreate-client`, `make shell-client`. localhost:8000 works.