### PR TITLE
Docs port warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Once that's downloaded, open up a terminal to the root `volunteer-portal` direct
 
 Include this [Service Account key](https://storage.cloud.google.com/humanity-forward-infra/gcp_credentials.json) called `gcp_credentials.json` in the `api/` folder. If you can't access this key, your onboarding process may not have been completed. reach out to a team lead to get that sorted.
 
-In the root directory of the repo, run the following command:
+In the root directory of the repo, run the following command to start the dev environment at `http://localhost:8000`:
 
 `docker-compose up`
 
 That command will take a while to run the first time you run it. It'll download a few OS images, set them up with the code in this repository and start the needed servers.
 
 Once that's done, open up [http://localhost:8000](http://localhost:8000) and you should see the application!
+:warning: **The client runs at 8080 and the api runs at 8081, but 8000 is the port you likely want to use** using 8080 to access the client you will not be able to interact with the API
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ In the root directory of the repo, run the following command to start the dev en
 That command will take a while to run the first time you run it. It'll download a few OS images, set them up with the code in this repository and start the needed servers.
 
 Once that's done, open up [http://localhost:8000](http://localhost:8000) and you should see the application!
+
 :warning: **The client runs at 8080 and the api runs at 8081, but 8000 is the port you likely want to use** using 8080 to access the client you will not be able to interact with the API
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ That command will take a while to run the first time you run it. It'll download 
 
 Once that's done, open up [http://localhost:8000](http://localhost:8000) and you should see the application!
 
-:warning: **The client runs at 8080 and the api runs at 8081, but 8000 is the port you likely want to use** using 8080 to access the client you will not be able to interact with the API
+:warning: **The client runs at 8080 and the api runs at 8081, but 8000 is the port you likely want to use for most development.** Using 8080 to access the client you will not be able to interact with the API.
 
 ## Testing
 


### PR DESCRIPTION
Open to other suggestions about how to make this more clear.

I think used the wrong port because I ran the "docker-compose up" command and then saw the client port info in my terminal and proceeded to test things from that port. So adding the appropriate port before the command seemed like one way to avoid using the wrong port.

We could also turn off the client port forwarding from docker.