### PR TITLE
Support absolute imports

### DIFF
--- a/client/jsconfig.json
+++ b/client/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
Support absolute imports. So we can do stuff like
```
import LoadingSpinner from "components/LoadingSpinner";
```
rather than
```
import LoadingSpinner from "../../components/LoadingSpinner";
```

see: https://create-react-app.dev/docs/importing-a-component/

## Test Plan
Made a change to an existing relative import, works