### PR TITLE
stop logging all nginx output

### DIFF
--- a/nginx/cloud_release_config
+++ b/nginx/cloud_release_config
@@ -6,8 +6,8 @@ http {
         listen 80;
         listen [::]:80;
 
-        access_log /tmp/nginx;
-        error_log /tmp/nginx;
+        access_log off;
+        error_log off;
 
         location / {
             proxy_pass http://localhost:8080;


### PR DESCRIPTION
This was dumping logs in a tmp file I don't think we have access to. We could have this log to std out and it should show up in GCP logging, but the api already logs there so these would be redundant. I think if we want to log requests to the client that should be on the client as well