### PR TITLE
implement reset password functionality

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,3 +1,4 @@
 from models import *
 from settings import *
 from security import *
+from helpers import *

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -227,7 +227,7 @@ def create_notification(username_or_email: AcctUsernameOrEmailSchema, db: Sessio
 
             url_to_click = f'{base_url}/reset_password?hash={password_reset_hash}'
             email_message += f'<p>We have received a request to reset your password. To reset your password, \
-                please click here: <a href="{url_to_click}">{url_to_click}</a></p> \
+                please click the following link: <a href="{url_to_click}">change my password</a></p> \
                 <p>This link will expire in 15 minutes.</p>'
         else:
             email_message += f'<p>We have received a request to reset your password. \

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -25,23 +25,21 @@ import socket
 
 router = APIRouter()
 
-# Note: I am leaving this route commented out as it should not be available publicly.
-# However, it is useful to have when running locally for debugging purposes
+# Note: I am leaving these get all routes commented out as they should not be available publicly.
+# However, they're useful to have when running locally for debugging purposes
+# @router.get("/accounts/", response_model=List[AccountResponseSchema])
+# def get_all_accounts(db: Session = Depends(get_db)):
+#     return db.query(Account).all()
 
 
-@router.get("/accounts/", response_model=List[AccountResponseSchema])
-def get_all_accounts(db: Session = Depends(get_db)):
-    return db.query(Account).all()
+# @router.get("/account_settings/", status_code=200)
+# def get_all_account_settings(db: Session = Depends(get_db)):
+#     return db.query(AccountSettings).all()
 
 
-@router.get("/account_settings/", status_code=200)
-def get_all_account_settings(db: Session = Depends(get_db)):
-    return db.query(AccountSettings).all()
-
-
-@router.get("/notifications/", status_code=200)
-def get_all_notifications(db: Session = Depends(get_db)):
-    return db.query(Notification).all()
+# @router.get("/notifications/", status_code=200)
+# def get_all_notifications(db: Session = Depends(get_db)):
+#     return db.query(Notification).all()
 
 
 def check_valid_password(password: str):
@@ -171,11 +169,6 @@ def create_settings(settings: AccountSettingsSchema, Authorize: AuthJWT = Depend
     return new_settings
 
 
-# @router.get("/account_settings/", response_model=List[AccountSettingsSchema])
-# def get_all_settings(db: Session = Depends(get_db)):
-#     return db.query(AccountSettings).all()
-
-
 @router.get("/account_settings/{uuid}", response_model=AccountSettingsSchema)
 def get_settings_by_uuid(uuid, db: Session = Depends(get_db), Authorize: AuthJWT = Depends()):
     Authorize.jwt_required()
@@ -267,9 +260,8 @@ def get_settings_from_hash(pw_reset_hash: str, Authorize: AuthJWT = Depends(), d
                             detail=f"Invalid or expired password reset URL!")
 
 
-def minutes_difference(reset_req_time):
-    m1 = datetime.now()
-    m2 = datetime.strptime(str(reset_req_time), '%Y-%m-%d %H:%M:%S.%f')
-    seconds_diff = abs((m1 - m2).seconds)
+def minutes_difference(reset_req_time: datetime):
+    curr_time = datetime.now()
+    seconds_diff = abs((curr_time - reset_req_time).seconds)
     minutes_diff = seconds_diff/60
     return minutes_diff

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -236,7 +236,7 @@ def create_notification(username_or_email: AcctUsernameOrEmailSchema, db: Sessio
             email_message += f'<p>We have received a request to reset your password. \
                 Your account was created with {oauth_type} OAuth; therefore, \
                 you cannot set or reset a password. \
-                "Please try signing in with {oauth_type}.</p>'
+                Please try signing in with {oauth_type}.</p>'
         email_message += '<b> If this action was not performed by you, \
                 someone may be targeting your account. You may want to consider changing your e-mail password. </b>\
                 <p>Regards, <br/>HF Volunteer Portal Team </p>'

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -27,6 +27,8 @@ router = APIRouter()
 
 # Note: I am leaving these get all routes commented out as they should not be available publicly.
 # However, they're useful to have when running locally for debugging purposes
+
+
 # @router.get("/accounts/", response_model=List[AccountResponseSchema])
 # def get_all_accounts(db: Session = Depends(get_db)):
 #     return db.query(Account).all()

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -6,6 +6,7 @@ from models.notification import Notification, NotificationChannel, NotificationS
 import notifications_manager as nm
 from schemas import (AccountRequestSchema, AccountResponseSchema,
                      PartialAccountSchema, AccountSettingsSchema, AcctUsernameOrEmailSchema)
+from sqlalchemy import or_
 from sqlalchemy.orm import lazyload
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import JSONResponse

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -24,7 +24,7 @@ from datetime import datetime
 import socket
 import random
 import decimal
-
+from helpers import sanitize_email
 router = APIRouter()
 
 # Note: I am leaving these get all routes commented out as they should not be available publicly.
@@ -207,10 +207,11 @@ def create_notification(username_or_email: AcctUsernameOrEmailSchema, db: Sessio
     existing_acct = None
     if username_or_email.email is not None:
         existing_acct = db.query(Account).filter_by(
-            email=username_or_email.email).first()
+            email=username_or_email.email).first() or db.query(Account).filter_by(
+                email=sanitize_email(username_or_email.email)).first()
     elif username_or_email.username is not None:
         existing_acct = db.query(Account).filter_by(
-            username=username_or_email.username).first()
+            username=username_or_email.username.strip()).first()
 
     email_message = None
     if existing_acct is not None:

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -1,0 +1,22 @@
+import re
+
+
+def sanitize_email(input_email: str) -> str:
+    val_array = input_email.strip().lower().split('@')
+    sani_user = re.sub(
+        r'\.', '', val_array[0]) if val_array[1] == 'gmail.com' else val_array[0]
+    return f'{sani_user}@{val_array[1]}'
+
+
+def trim_str(input: str) -> str:
+    return input.strip() if input else input
+
+
+def sanitize_data(payload):
+    for key in payload:
+        if key == 'email':
+            payload[key] = sanitize_email(payload[key])
+        elif key == 'password':
+            continue
+        else:
+            payload[key] = trim_str(payload[key])

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -1,6 +1,6 @@
 from models.base import Base
 
-from sqlalchemy import func, select, Column, String, Integer, Text, Boolean
+from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, DateTime
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
 from sqlalchemy.orm import backref, column_property, relationship, synonym
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -24,7 +24,10 @@ class AccountSettings(Base):
         'volunteers_can_see', Boolean, default=True, nullable=False)
     # dictionary with initiative_name -> isSubscribed
     initiative_map = Column('initiative_map', JSON, default={}, nullable=False)
+    password_reset_hash = Column('password_reset_hash', Text, nullable=True)
+    # password_reset_time = Column(
+    #     'password_reset_time', DateTime, nullable=True)
 
     def __repr__(self):
-        return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s')>" % (
-            self.uuid, self.show_name, self.show_email, self.show_location, self.organizers_can_see, self.volunteers_can_see, self.initiative_map)
+        return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s')>" % (
+            self.uuid, self.show_name, self.show_email, self.show_location, self.organizers_can_see, self.volunteers_can_see, self.initiative_map, self.password_reset_hash)

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -25,8 +25,8 @@ class AccountSettings(Base):
     # dictionary with initiative_name -> isSubscribed
     initiative_map = Column('initiative_map', JSON, default={}, nullable=False)
     password_reset_hash = Column('password_reset_hash', Text, nullable=True)
-    # password_reset_time = Column(
-    #     'password_reset_time', DateTime, nullable=True)
+    password_reset_time = Column(
+        'password_reset_time', DateTime, nullable=True)
 
     def __repr__(self):
         return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s')>" % (

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -29,5 +29,5 @@ class AccountSettings(Base):
         'password_reset_time', DateTime, nullable=True)
 
     def __repr__(self):
-        return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s')>" % (
-            self.uuid, self.show_name, self.show_email, self.show_location, self.organizers_can_see, self.volunteers_can_see, self.initiative_map, self.password_reset_hash)
+        return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s', password_reset_time='%s')>" % (
+            self.uuid, self.show_name, self.show_email, self.show_location, self.organizers_can_see, self.volunteers_can_see, self.initiative_map, self.password_reset_hash, self.password_reset_time)

--- a/api/models/notification.py
+++ b/api/models/notification.py
@@ -27,6 +27,7 @@ class Notification(Base):
         UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
     channel = Column('channel', Enum(NotificationChannel), nullable=False)
     recipient = Column('recipient', Text, nullable=False)
+    subject = Column('subject', Text, nullable=True)
     message = Column('message', Text, nullable=False)
     scheduled_send_date = Column(
         'scheduled_send_date', DateTime, default=func.now(), nullable=False)

--- a/api/notifications_manager.py
+++ b/api/notifications_manager.py
@@ -9,23 +9,27 @@ from email_validator import validate_email
 from twilio.rest import Client
 import phonenumbers
 from slack_sdk import WebClient
+from urllib.request import urlopen
 
 logging.basicConfig()
 logging.getLogger('notifications_manager').setLevel(logging.INFO)
 
 email_client = SendGridAPIClient(Config['notifications']['sendgrid_api_key'])
-sms_client = Client(Config['notifications']['twilio_sid'], Config['notifications']['twilio_auth_token'])
+sms_client = Client(Config['notifications']['twilio_sid'],
+                    Config['notifications']['twilio_auth_token'])
 slack_client = WebClient(token=Config['notifications']['slack_bot_auth_token'])
 
+
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
-def send_notification(recipient: str, message: str, channel: NotificationChannel, scheduled_send_date: datetime = None):
+def send_notification(recipient: str, message: str, channel: NotificationChannel, scheduled_send_date: datetime = None, subject=None):
     notification = Notification(
-        recipient = recipient,
-        message = message,
-        channel = channel,
-        scheduled_send_date = scheduled_send_date
+        recipient=recipient,
+        subject=subject,
+        message=message,
+        channel=channel,
+        scheduled_send_date=scheduled_send_date
     )
-    
+
     db = Session()
     db.add(notification)
 
@@ -40,6 +44,7 @@ def send_notification(recipient: str, message: str, channel: NotificationChannel
 
     db.commit()
 
+
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def send_email_notification(notification: Notification):
     try:
@@ -50,20 +55,23 @@ def send_email_notification(notification: Notification):
         email = Mail(
             from_email=Config['notifications']['email_default_from_address'],
             to_emails=recipient_email_address,
-            subject='This is a test Vol Portal Email',
-            html_content=f'<strong>Test email with message</strong> {notification.message}'
+            subject=notification.subject or 'This is a test Vol Portal Email',
+            html_content=notification.message or '<strong>Test email with message</strong> <p>E-mail is working!</p>'
         )
 
         response = email_client.send(email)
+        # open_url = urlopen(response)
+        print('What is response?', response)
         if response.ok:
             notification.status = NotificationStatus.SENT
             notification.sent_date = datetime.utcnow()
         else:
             notification.status = NotificationStatus.FAILED
-    
+
     except Exception as e:
         logging.error(e)
         notification.status = NotificationStatus.FAILED
+
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def send_sms_notification(notification: Notification):
@@ -71,12 +79,14 @@ def send_sms_notification(notification: Notification):
     try:
         assert notification.channel is NotificationChannel.SMS
 
-        recipient_phone_number = phonenumbers.parse(notification.recipient, None)
+        recipient_phone_number = phonenumbers.parse(
+            notification.recipient, None)
         assert phonenumbers.is_valid_number(recipient_phone_number) is True
 
         response = sms_client.messages.create(
             from_=Config['notifications']['sms_default_from_number'],
-            to=phonenumbers.format_number(recipient_phone_number, phonenumbers.PhoneNumberFormat.E164),
+            to=phonenumbers.format_number(
+                recipient_phone_number, phonenumbers.PhoneNumberFormat.E164),
             body=notification.message
         )
 
@@ -85,10 +95,11 @@ def send_sms_notification(notification: Notification):
             notification.sent_date = datetime.utcnow()
         else:
             notification.status = NotificationStatus.FAILED
-    
+
     except Exception as e:
         logging.error(e)
         notification.status = NotificationStatus.FAILED
+
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def send_slack_notification(notification: Notification):
@@ -103,7 +114,7 @@ def send_slack_notification(notification: Notification):
         # WebClient automatically raises a SlackApiError if response.ok is False; no need to check
         notification.status = NotificationStatus.SENT
         notification.sent_date = datetime.utcnow()
-    
+
     except Exception as e:
         logging.error(e)
         notification.status = NotificationStatus.FAILED

--- a/api/notifications_manager.py
+++ b/api/notifications_manager.py
@@ -60,9 +60,8 @@ def send_email_notification(notification: Notification):
         )
 
         response = email_client.send(email)
-        # open_url = urlopen(response)
-        print('What is response?', response)
-        if response.ok:
+
+        if response.status_code < 300:
             notification.status = NotificationStatus.SENT
             notification.sent_date = datetime.utcnow()
         else:

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -3,4 +3,4 @@ from schemas.volunteer_event import VolunteerEventSchema
 from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountRequestSchema, AccountResponseSchema,
                              AccountBasicLoginSchema, AccountPasswordSchema, PartialAccountSchema, AcctUsernameOrEmailSchema)
-from schemas.account_settings import AccountSettingsSchema
+from schemas.account_settings import AccountSettingsSchema, PasswordResetSchema

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -2,5 +2,5 @@ from schemas.initiative import InitiativeSchema, NestedInitiativeSchema
 from schemas.volunteer_event import VolunteerEventSchema
 from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountRequestSchema, AccountResponseSchema,
-                             AccountBasicLoginSchema, AccountPasswordSchema, PartialAccountSchema)
+                             AccountBasicLoginSchema, AccountPasswordSchema, PartialAccountSchema, AcctUsernameOrEmailSchema)
 from schemas.account_settings import AccountSettingsSchema

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -3,4 +3,4 @@ from schemas.volunteer_event import VolunteerEventSchema
 from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountRequestSchema, AccountResponseSchema,
                              AccountBasicLoginSchema, AccountPasswordSchema, PartialAccountSchema, AcctUsernameOrEmailSchema)
-from schemas.account_settings import AccountSettingsSchema, PasswordResetSchema
+from schemas.account_settings import AccountSettingsSchema

--- a/api/schemas/account.py
+++ b/api/schemas/account.py
@@ -44,3 +44,8 @@ class PartialAccountSchema(BaseModel):
     state: Optional[str]
     zip_code: Optional[str]
     roles: Optional[List]
+
+
+class AcctUsernameOrEmailSchema(BaseModel):
+    username: Optional[str]
+    email: Optional[str]

--- a/api/schemas/account_settings.py
+++ b/api/schemas/account_settings.py
@@ -16,8 +16,3 @@ class AccountSettingsSchema(BaseModel):
 
     class Config:
         orm_mode = True
-
-
-class PasswordResetSchema(BaseModel):
-    password_reset_hash: Optional[Text]
-    password_reset_time: Optional[Text]

--- a/api/schemas/account_settings.py
+++ b/api/schemas/account_settings.py
@@ -11,6 +11,13 @@ class AccountSettingsSchema(BaseModel):
     organizers_can_see: bool
     volunteers_can_see: bool
     initiative_map: Dict
+    password_reset_hash: Optional[Text]
+    password_reset_time: Optional[Text]
 
     class Config:
         orm_mode = True
+
+
+class PasswordResetSchema(BaseModel):
+    password_reset_hash: Optional[Text]
+    password_reset_time: Optional[Text]

--- a/api/schemas/account_settings.py
+++ b/api/schemas/account_settings.py
@@ -1,5 +1,6 @@
 from pydantic import BaseModel, EmailStr
 from typing import List, Dict, Text, Optional
+from datetime import datetime
 from uuid import UUID
 
 
@@ -12,7 +13,7 @@ class AccountSettingsSchema(BaseModel):
     volunteers_can_see: bool
     initiative_map: Dict
     password_reset_hash: Optional[Text]
-    password_reset_time: Optional[Text]
+    password_reset_time: Optional[datetime]
 
     class Config:
         orm_mode = True

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -82,7 +82,7 @@ def test_send_email_success(mock_send, db):
 def test_send_email_failure(mock_send, db):
     mock_send.return_value = MockResponse(False)
 
-    email_address = 'good.email@exmaple.com'
+    email_address = 'asdf@!'
     message = fake.paragraph(nb_sentences=10)
     nm.send_notification(email_address, message, NotificationChannel.EMAIL)
 

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -94,7 +94,7 @@ function Header(props) {
     if (user) {
       cookies.set('user_id', user.uuid, {
         path: '/',
-        sameSite: true,
+        sameSite: 'none',
         secure: true,
       });
     }

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -94,7 +94,7 @@ function Header(props) {
     if (user) {
       cookies.set('user_id', user.uuid, {
         path: '/',
-        sameSite: 'None',
+        sameSite: true,
         secure: true,
       });
     }

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -59,7 +59,7 @@ function Login(props) {
                 handleChange('email', e.target.value);
               }}
               required
-              isInvalid={!!errors.email}
+              isInvalid={!!errors.email || !!errors.message}
             />
             <Form.Control.Feedback type="invalid">
               {!data.email ? 'Please provide an e-mail address.' : errors.email}

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import GoogleOAuthButton from 'components/oauth/GoogleOAuthButton';
 import GitHubOAuthButton from 'components/oauth/GitHubOAuthButton';
 import LoadingSpinner from './LoadingSpinner';
-import PasswordResetModal from 'components/modals/PasswordResetModal';
+import ForgotPasswordModal from 'components/modals/ForgotPasswordModal';
 
 import 'styles/register-login.scss';
 
@@ -97,7 +97,7 @@ function Login(props) {
             </Button>
           </div>
         </Form>
-        <PasswordResetModal
+        <ForgotPasswordModal
           show={showModal}
           onHide={() => setShowModal(false)}
         />

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -87,7 +87,7 @@ function Login(props) {
                 style={{ color: 'gray' }}
                 onClick={() => setShowModal(true)}
               >
-                Forgot password?
+                <u>Forgot password?</u>
               </p>
             </div>
           </Form.Group>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -81,7 +81,7 @@ function Login(props) {
                 ? 'Please provide a password.'
                 : errors.password || errors.message}
             </Form.Control.Feedback>
-            <div className="mt-2 mb-2">
+            <div className="mt-3 mb-3">
               <p
                 className="font-weight-light hover-hand-and-underline"
                 style={{ color: 'gray' }}

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -4,7 +4,6 @@ import useForm from './hooks/useForm';
 import { Button, Form, Container, Row, Col } from 'react-bootstrap';
 import { attemptLogin } from 'store/user-slice/index.js';
 import { Redirect } from 'react-router-dom';
-import { Link } from 'react-router-dom';
 
 import GoogleOAuthButton from 'components/oauth/GoogleOAuthButton';
 import GitHubOAuthButton from 'components/oauth/GitHubOAuthButton';

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -5,13 +5,17 @@ import { Button, Form, Container, Row, Col } from 'react-bootstrap';
 import { attemptLogin } from 'store/user-slice/index.js';
 import { Redirect } from 'react-router-dom';
 import { Link } from 'react-router-dom';
+
 import GoogleOAuthButton from 'components/oauth/GoogleOAuthButton';
 import GitHubOAuthButton from 'components/oauth/GitHubOAuthButton';
 import LoadingSpinner from './LoadingSpinner';
+import PasswordResetModal from 'components/modals/PasswordResetModal';
+
 import 'styles/register-login.scss';
 
 function Login(props) {
   const [pendingSubmit, setPendingSubmit] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const { attemptLogin, user, firstAcctPage, initLoading } = props;
   const { validated, errors, handleSubmit, handleChange, data } = useForm(
     attemptLogin
@@ -78,13 +82,13 @@ function Login(props) {
                 : errors.password || errors.message}
             </Form.Control.Feedback>
             <div className="mt-2 mb-2">
-              <Link
-                className="font-weight-light"
+              <p
+                className="font-weight-light hover-hand-and-underline"
                 style={{ color: 'gray' }}
-                to="/forgot_password"
+                onClick={() => setShowModal(true)}
               >
-                Forgot Password?
-              </Link>
+                Forgot password?
+              </p>
             </div>
           </Form.Group>
           <div className="text-center">
@@ -93,6 +97,10 @@ function Login(props) {
             </Button>
           </div>
         </Form>
+        <PasswordResetModal
+          show={showModal}
+          onHide={() => setShowModal(false)}
+        />
       </Container>
     </>
   );

--- a/client/src/components/LoginCallback.js
+++ b/client/src/components/LoginCallback.js
@@ -13,7 +13,7 @@ function LoginCallback(props) {
       if (window.location.pathname.includes('/login_callback')) {
         setErrorLoading(true);
       }
-    }, 2500);
+    }, 3000);
   }, []);
 
   useEffect(() => {

--- a/client/src/components/PageViewSwitch.js
+++ b/client/src/components/PageViewSwitch.js
@@ -15,6 +15,7 @@ import NotFound from './NotFound';
 import Login from './Login';
 import LoginCallback from './LoginCallback';
 import Dashboard from './Dashboard';
+import ResetPassword from './ResetPassword';
 
 // initialize GA
 // REACT_APP_GA_TRACKING_ID can be found in .env
@@ -51,6 +52,7 @@ function PageViewSwitch() {
         <Route path="/login_callback" exact component={LoginCallback} />
         <Route path="/dashboard" exact component={Dashboard} />
         <Route path="/account/*" component={Account} />
+        <Route path="/reset_password" component={ResetPassword} />
         <Route path="*" component={NotFound} />
       </Switch>
     </Container>

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { connect } from 'react-redux';
-import { Button, Form, Container, Row, Col, Alert } from 'react-bootstrap';
+import { Button, Form, Row, Col, Alert } from 'react-bootstrap';
 import { Redirect } from 'react-router-dom';
 import useForm from 'components/hooks/useForm';
 import { attemptRegister } from 'store/user-slice';

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Button, Form, Container, Row, Col, Alert } from 'react-bootstrap';
 import { Redirect } from 'react-router-dom';
 import useForm from 'components/hooks/useForm';
-import { attemptCreateAccount } from 'store/user-slice';
+import { attemptRegister } from 'store/user-slice';
 import LinesAroundOr from './LinesAroundOr';
 import OAuthGroup from 'components/oauth/OAuthGroup';
 import 'styles/register-login.scss';
@@ -11,7 +11,7 @@ import 'styles/register-login.scss';
 function Register(props) {
   document.title = 'HF Volunteer Portal - Create an Account';
   const [pendingSubmit, setPendingSubmit] = useState(false);
-  const { user, attemptCreateAccount } = props;
+  const { user, attemptRegister } = props;
   const {
     handleChange,
     handleSubmit,
@@ -21,7 +21,7 @@ function Register(props) {
     validated,
     setValidated,
     errors,
-  } = useForm(attemptCreateAccount);
+  } = useForm(attemptRegister);
   const path = window.location.pathname;
 
   const submitWrapper = async (e) => {
@@ -79,7 +79,7 @@ function Register(props) {
                   <Form.Group controlId="formFirstName">
                     <Form.Label>First Name</Form.Label>
                     <Form.Control
-                      type="name"
+                      type="text"
                       placeholder="First Name"
                       onChange={(e) => {
                         handleKeyPress('first_name', e);
@@ -100,7 +100,7 @@ function Register(props) {
                   <Form.Group controlId="formLastName">
                     <Form.Label>Last Name</Form.Label>
                     <Form.Control
-                      type="name"
+                      type="text"
                       placeholder="Enter last name here (optional)"
                       onChange={(e) => {
                         handleKeyPress('last_name', e);
@@ -118,7 +118,7 @@ function Register(props) {
               <Form.Group controlId="formUsername">
                 <Form.Label>Username</Form.Label>
                 <Form.Control
-                  type="username"
+                  type="text"
                   onChange={(e) => {
                     handleKeyPress('username', e);
                   }}
@@ -214,6 +214,6 @@ const mapStateToProps = (state) => {
     user: state.userStore.user,
   };
 };
-const mapDispatchToProps = { attemptCreateAccount };
+const mapDispatchToProps = { attemptRegister };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Register);

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -5,7 +5,10 @@ import { Link } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
 
 import useForm from 'components/hooks/useForm';
-import { attemptResetPassword, getSettingsFromHash } from 'store/user-slice';
+import {
+  attemptResetPassword,
+  getSettingsFromHash,
+} from 'store/user-slice/reset-password';
 import LoadingSpinner from './LoadingSpinner';
 import { startLogout } from 'store/user-slice';
 

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -1,0 +1,106 @@
+import React, { useEffect, useState } from 'react';
+import { Button, Form } from 'react-bootstrap';
+
+import useForm from 'components/hooks/useForm';
+import { attemptResetPassword, getSettingsFromHash } from 'store/user-slice';
+import LoadingSpinner from './LoadingSpinner';
+
+function ResetPassword(props) {
+  const [loading, setLoading] = useState(false);
+  // const [errorLoading, setErrorLoading] = useState(false);
+  const [settings, setSettings] = useState(null);
+
+  useEffect(async () => {
+    try {
+      setLoading(true);
+      const params = new URLSearchParams(window.location.search);
+      const hash = params.get('hash');
+      const loadedSettings = await getSettingsFromHash(hash);
+      setSettings(loadedSettings);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const {
+    validated,
+    submitted,
+    errors,
+    handleSubmit,
+    handleChange,
+    data,
+    resetForm,
+  } = useForm(attemptResetPassword, { uuid: settings ? settings.uuid : null });
+
+  return loading ? (
+    <LoadingSpinner />
+  ) : settings && submitted ? (
+    <>
+      <h2 className="text-center">Password reset successfully!</h2>
+      <p>
+        You can now go back to the
+        <Link to="/login">login page</Link> and log in with your new password.
+      </p>
+    </>
+  ) : settings ? (
+    <>
+      <h2>Reset Password</h2>
+      <Form
+        noValidate
+        validated={validated}
+        onSubmit={handleSubmit}
+        className="mt-5 mb-5"
+      >
+        <Form.Group controlId="reset-new-password">
+          <Form.Label>New password</Form.Label>
+          <Form.Control
+            type="password"
+            placeholder="Enter new password (required)"
+            onChange={(e) => {
+              handleChange('password', e.target.value);
+            }}
+            isInvalid={validated && (!data.password || !!errors.password)}
+            required
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.password}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group controlId="reset-retype-password">
+          <Form.Label>Retype password</Form.Label>
+          <Form.Control
+            type="password"
+            placeholder="Enter new password (required)"
+            onChange={(e) => {
+              handleChange('retypePass', e.target.value);
+            }}
+            isInvalid={validated && (!data.retypePass || !!errors.retypePass)}
+            required
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.retypePass}
+          </Form.Control.Feedback>
+        </Form.Group>
+        <div className="text-center">
+          <Button variant="info" type="submit" className="mt-5 mb-3" block>
+            Change Password
+          </Button>
+        </div>
+      </Form>
+    </>
+  ) : (
+    <>
+      <h2 className="text-center">
+        Oops, it looks like this password reset link is invalid or expired!
+      </h2>
+      <p>
+        Please try again by requesting a password reset on the{' '}
+        <Link to="/login">login page.</Link>
+      </p>
+    </>
+  );
+}
+
+export default ResetPassword;

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -1,14 +1,18 @@
 import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
 import { Button, Form } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
+import { withCookies } from 'react-cookie';
 
 import useForm from 'components/hooks/useForm';
 import { attemptResetPassword, getSettingsFromHash } from 'store/user-slice';
 import LoadingSpinner from './LoadingSpinner';
+import { startLogout } from 'store/user-slice';
 
 function ResetPassword(props) {
   const [loading, setLoading] = useState(false);
   const [errorLoading, setErrorLoading] = useState(false);
+  const { user, cookies, startLogout } = props;
   const {
     validated,
     submitted,
@@ -27,6 +31,12 @@ function ResetPassword(props) {
       .catch(() => setErrorLoading(true))
       .finally(() => setLoading(false));
   }, []);
+
+  useEffect(() => {
+    if (user) {
+      startLogout(cookies);
+    }
+  }, [user]);
 
   return loading ? (
     <LoadingSpinner />
@@ -100,4 +110,16 @@ function ResetPassword(props) {
   ) : null;
 }
 
-export default ResetPassword;
+const mapStateToProps = (state) => {
+  return {
+    user: state.userStore.user,
+  };
+};
+
+const mapDispatchToProps = {
+  startLogout,
+};
+
+export default withCookies(
+  connect(mapStateToProps, mapDispatchToProps)(ResetPassword)
+);

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -66,7 +66,7 @@ function ResetPassword(props) {
             onChange={(e) => {
               handleChange('password', e.target.value);
             }}
-            isInvalid={validated && (!data.password || !!errors.password)}
+            isInvalid={!!errors.password}
             required
           />
           <Form.Control.Feedback type="invalid">
@@ -81,7 +81,7 @@ function ResetPassword(props) {
             onChange={(e) => {
               handleChange('retypePass', e.target.value);
             }}
-            isInvalid={validated && (!data.retypePass || !!errors.retypePass)}
+            isInvalid={!!errors.retypePass}
             required
           />
           <Form.Control.Feedback type="invalid">

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -9,8 +9,6 @@ import LoadingSpinner from './LoadingSpinner';
 function ResetPassword(props) {
   const [loading, setLoading] = useState(false);
   const [errorLoading, setErrorLoading] = useState(false);
-  const [settings, setSettings] = useState(null);
-
   const {
     validated,
     submitted,

--- a/client/src/components/hooks/useForm.js
+++ b/client/src/components/hooks/useForm.js
@@ -44,8 +44,8 @@ const useForm = (callback, initObj) => {
       setValidated(true);
       setSubmitted(true);
       return true;
-    } catch (error) {
-      setErrors(error);
+    } catch (errors) {
+      setErrors(errors);
       setValidated(true);
       setSubmitted(false);
       return false;

--- a/client/src/components/hooks/useForm.js
+++ b/client/src/components/hooks/useForm.js
@@ -46,7 +46,7 @@ const useForm = (callback, initObj) => {
       return true;
     } catch (errors) {
       setErrors(errors);
-      setValidated(true);
+      // setValidated(true);
       setSubmitted(false);
       return false;
     }

--- a/client/src/components/modals/ForgotPasswordModal.js
+++ b/client/src/components/modals/ForgotPasswordModal.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
-import { connect } from 'react-redux';
-import { Button, Form, Container, Row, Col } from 'react-bootstrap';
+import { Button, Form } from 'react-bootstrap';
 
 import useForm from 'components/hooks/useForm';
 import { attemptSendResetEmail } from 'store/user-slice';
 
-function PasswordResetModal(props) {
+function ForgotPasswordModal(props) {
   const {
     validated,
     submitted,
@@ -50,7 +49,7 @@ function PasswordResetModal(props) {
             onSubmit={handleSubmit}
             className="mt-5 mb-5"
           >
-            <Form.Group controlId="reset-password-form">
+            <Form.Group controlId="forgot-password-request">
               <Form.Label>Username or e-mail address</Form.Label>
               <Form.Control
                 type="text"
@@ -80,4 +79,4 @@ function PasswordResetModal(props) {
   );
 }
 
-export default PasswordResetModal;
+export default ForgotPasswordModal;

--- a/client/src/components/modals/ForgotPasswordModal.js
+++ b/client/src/components/modals/ForgotPasswordModal.js
@@ -53,7 +53,7 @@ function ForgotPasswordModal(props) {
               <Form.Label>Username or e-mail address</Form.Label>
               <Form.Control
                 type="text"
-                placeholder="Enter username or e-mail address (required)"
+                placeholder="Enter username or e-mail address"
                 onChange={(e) => {
                   handleChange('username_or_email', e.target.value);
                 }}

--- a/client/src/components/modals/ForgotPasswordModal.js
+++ b/client/src/components/modals/ForgotPasswordModal.js
@@ -3,7 +3,7 @@ import { Modal } from 'react-bootstrap';
 import { Button, Form } from 'react-bootstrap';
 
 import useForm from 'components/hooks/useForm';
-import { attemptSendResetEmail } from 'store/user-slice';
+import { attemptSendResetEmail } from 'store/user-slice/reset-password';
 
 function ForgotPasswordModal(props) {
   const {

--- a/client/src/components/modals/ForgotPasswordModal.js
+++ b/client/src/components/modals/ForgotPasswordModal.js
@@ -57,10 +57,7 @@ function ForgotPasswordModal(props) {
                 onChange={(e) => {
                   handleChange('username_or_email', e.target.value);
                 }}
-                isInvalid={
-                  validated &&
-                  (!data.username_or_email || !!errors.usernameOrEmail)
-                }
+                isInvalid={!!errors.usernameOrEmail}
                 required
               />
               <Form.Control.Feedback type="invalid">

--- a/client/src/components/modals/PasswordResetModal.js
+++ b/client/src/components/modals/PasswordResetModal.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Modal } from 'react-bootstrap';
+import { connect } from 'react-redux';
+import { Button, Form, Container, Row, Col } from 'react-bootstrap';
+
+import useForm from 'components/hooks/useForm';
+import { attemptSendResetEmail } from 'store/user-slice';
+
+function PasswordResetModal(props) {
+  const {
+    validated,
+    submitted,
+    errors,
+    handleSubmit,
+    handleChange,
+    data,
+  } = useForm(attemptSendResetEmail);
+
+  return (
+    <Modal {...props} size="lg" centered>
+      <Modal.Header closeButton />
+      <Modal.Body>
+        <h2 className="text-center mt-4 mb-4">Reset Password</h2>
+        <Form
+          noValidate
+          validated={validated}
+          onSubmit={handleSubmit}
+          className="mt-5 mb-5"
+        >
+          <Form.Group controlId="reset-password-form">
+            <Form.Label>Username or e-mail address</Form.Label>
+            <Form.Control
+              type="text"
+              placeholder="Enter username or e-mail address (required)"
+              onChange={(e) => {
+                handleChange('username_or_email', e.target.value);
+              }}
+              isInvalid={
+                validated &&
+                (!data.username_or_email || Object.keys(errors).length)
+              }
+              required
+            />
+            <Form.Control.Feedback type="invalid">
+              This is not a valid username or e-mail format. Please try again.
+            </Form.Control.Feedback>
+          </Form.Group>
+          <div className="text-center">
+            <Button variant="info" type="submit" className="mt-5 mb-3" block>
+              Reset Password
+            </Button>
+          </div>
+        </Form>
+      </Modal.Body>
+    </Modal>
+  );
+}
+
+// const mapDispatchToProps = {
+//   attemptSendResetEmail,
+// };
+
+// export default connect(null, mapDispatchToProps)(PasswordReset);
+export default PasswordResetModal;

--- a/client/src/components/modals/PasswordResetModal.js
+++ b/client/src/components/modals/PasswordResetModal.js
@@ -14,51 +14,70 @@ function PasswordResetModal(props) {
     handleSubmit,
     handleChange,
     data,
+    resetForm,
   } = useForm(attemptSendResetEmail);
 
+  const clearFormAndHide = () => {
+    props.onHide();
+    resetForm();
+  };
+
   return (
-    <Modal {...props} size="lg" centered>
+    <Modal {...props} size="lg" onExited={clearFormAndHide} centered>
       <Modal.Header closeButton />
-      <Modal.Body>
-        <h2 className="text-center mt-4 mb-4">Reset Password</h2>
-        <Form
-          noValidate
-          validated={validated}
-          onSubmit={handleSubmit}
-          className="mt-5 mb-5"
-        >
-          <Form.Group controlId="reset-password-form">
-            <Form.Label>Username or e-mail address</Form.Label>
-            <Form.Control
-              type="text"
-              placeholder="Enter username or e-mail address (required)"
-              onChange={(e) => {
-                handleChange('username_or_email', e.target.value);
-              }}
-              isInvalid={
-                validated &&
-                (!data.username_or_email || Object.keys(errors).length)
-              }
-              required
-            />
-            <Form.Control.Feedback type="invalid">
-              This is not a valid username or e-mail format. Please try again.
-            </Form.Control.Feedback>
-          </Form.Group>
-          <div className="text-center">
-            <Button variant="info" type="submit" className="mt-5 mb-3" block>
-              Reset Password
+      {submitted ? (
+        <Modal.Body>
+          <h4 className="m-4">
+            If we have you on record, we will send you an e-mail to reset your
+            password.
+          </h4>
+          <div className="text-right">
+            <Button
+              variant="outline-info"
+              className="m-4"
+              onClick={clearFormAndHide}
+            >
+              Return
             </Button>
           </div>
-        </Form>
-      </Modal.Body>
+        </Modal.Body>
+      ) : (
+        <Modal.Body>
+          <h2 className="text-center mt-4 mb-4">Reset Password</h2>
+          <Form
+            noValidate
+            validated={validated}
+            onSubmit={handleSubmit}
+            className="mt-5 mb-5"
+          >
+            <Form.Group controlId="reset-password-form">
+              <Form.Label>Username or e-mail address</Form.Label>
+              <Form.Control
+                type="text"
+                placeholder="Enter username or e-mail address (required)"
+                onChange={(e) => {
+                  handleChange('username_or_email', e.target.value);
+                }}
+                isInvalid={
+                  validated &&
+                  (!data.username_or_email || !!errors.usernameOrEmail)
+                }
+                required
+              />
+              <Form.Control.Feedback type="invalid">
+                This is not a valid username or e-mail format. Please try again.
+              </Form.Control.Feedback>
+            </Form.Group>
+            <div className="text-center">
+              <Button variant="info" type="submit" className="mt-5 mb-3" block>
+                Reset Password
+              </Button>
+            </div>
+          </Form>
+        </Modal.Body>
+      )}
     </Modal>
   );
 }
 
-// const mapDispatchToProps = {
-//   attemptSendResetEmail,
-// };
-
-// export default connect(null, mapDispatchToProps)(PasswordReset);
 export default PasswordResetModal;

--- a/client/src/components/modals/PasswordResetModal.js
+++ b/client/src/components/modals/PasswordResetModal.js
@@ -34,7 +34,7 @@ function PasswordResetModal(props) {
           <div className="text-right">
             <Button
               variant="outline-info"
-              className="m-4"
+              className="m-4 py-2 px-4"
               onClick={clearFormAndHide}
             >
               Return

--- a/client/src/store/user-slice/classes.js
+++ b/client/src/store/user-slice/classes.js
@@ -23,5 +23,7 @@ export class SettingsReqBody {
     this.organizers_can_see = obj.organizers_can_see ?? true;
     this.volunteers_can_see = obj.volunteers_can_see ?? true;
     this.initiative_map = obj.initiative_map || {};
+    this.password_reset_hash = obj.password_reset_hash ?? null;
+    this.password_reset_time = obj.password_reset_time ?? null;
   }
 }

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -65,7 +65,6 @@ export const sanitizeData = (payload) => {
       case 'state':
       case 'zip_code':
       case 'username':
-      case 'password':
         payload[key] = val ? val.trim() : val;
         break;
       case 'email':

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -65,6 +65,7 @@ export const sanitizeData = (payload) => {
       case 'state':
       case 'zip_code':
       case 'username':
+      case 'password':
         payload[key] = val ? val.trim() : val;
         break;
       case 'email':

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -24,6 +24,16 @@ export const validateEmail = (email) => {
     : 'Please provide a valid e-mail address (i.e. andy@test.com)';
 };
 
+export const validateUsername = (username) => {
+  if (!username) {
+    return 'Please provide a username';
+  }
+  const isValidAlphaNumericUni = !validateAlphaNumericUnicode(username);
+  return isValidAlphaNumericUni && username.length > 4 && username.length < 26
+    ? null
+    : 'Please enter a username using alphanumeric characters between 5 and and 25 characters in length';
+};
+
 /*
     Credit: https://stackoverflow.com/questions/388996/regex-for-javascript-to-allow-only-alphanumeric
 */

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -68,7 +68,7 @@ export const sanitizeData = (payload) => {
         payload[key] = val ? val.trim() : val;
         break;
       case 'email':
-        if (val) {
+        if (val && !payload.oauth) {
           let strArr = val.trim().toLowerCase().split('@');
           const saniUser =
             strArr[1] === 'gmail.com'

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -102,3 +102,31 @@ export const formHasNoErrors = (errors) => {
   }
   return true;
 };
+
+export const handleApiErrors = (response, errors) => {
+  if (response) {
+    if (
+      response.data &&
+      response.data.detail &&
+      Object.keys(response.data.detail)
+    ) {
+      Object.entries(response.data.detail).forEach((entry) => {
+        const [key, val] = entry;
+        errors[key] = val;
+      });
+    } else {
+      errors.api =
+        response.data.detail ||
+        'Error while attempting to create an account. Please try again later.';
+    }
+  }
+};
+
+export const handlePossibleExpiredToken = (error) => {
+  if (
+    error.response &&
+    (error.response.status === 422 || error.response.status === 401)
+  ) {
+    window.location.reload();
+  }
+};

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -28,8 +28,12 @@ export const validateUsername = (username) => {
   if (!username) {
     return 'Please provide a username';
   }
+
   const isValidAlphaNumericUni = !validateAlphaNumericUnicode(username);
-  return isValidAlphaNumericUni && username.length > 4 && username.length < 26
+  const trimmedUserName = username.trim();
+  return isValidAlphaNumericUni &&
+    trimmedUserName.length > 4 &&
+    trimmedUserName.length < 26
     ? null
     : 'Please enter a username using alphanumeric characters between 5 and and 25 characters in length';
 };
@@ -39,13 +43,19 @@ export const validateUsername = (username) => {
 */
 export const validateAlphaNumericUnicode = (word) => {
   const pattern = /^([a-zA-Z0-9\u0600-\u06FF\u0660-\u0669\u06F0-\u06F9 _.-]+)$/;
-  const isValid = pattern.test(word);
+  const isValid = word && word.trim() && pattern.test(word);
   return isValid ? null : 'Please only use alphanumeric or unicode characters.';
 };
 
 export const validatePassRetype = (password, retypePass) => {
+  if (!retypePass) {
+    return 'Please retype your password.';
+  }
+
   const passesMatch = password === retypePass;
-  return passesMatch ? null : 'Password and retyped passwords do not match.';
+  return passesMatch
+    ? validatePassword(retypePass)
+    : 'Password and retyped password do not match.';
 };
 
 export const validateZipCode = (zipCode) => {

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -70,7 +70,10 @@ export const sanitizeData = (payload) => {
       case 'email':
         if (val) {
           let strArr = val.trim().toLowerCase().split('@');
-          const saniUser = strArr[0].replace(/\./g, '');
+          const saniUser =
+            strArr[1] === 'gmail.com'
+              ? strArr[0].replace(/\./g, '')
+              : strArr[0];
           payload[key] = `${saniUser}@${strArr[1]}`;
         }
         break;

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -401,7 +401,7 @@ export const attemptUpdateAccount = (payload) => async (dispatch) => {
   throw errors;
 };
 
-export const attemptSendResetEmail = (payload) => {
+export const attemptSendResetEmail = async (payload) => {
   const { username_or_email } = payload;
   const errors = {};
   const hasUsernameErr = validateUsername(username_or_email);
@@ -412,6 +412,14 @@ export const attemptSendResetEmail = (payload) => {
     throw errors;
   } else {
     console.log('hooray!');
+    const obj = {};
+    if (!hasEmailErr) {
+      obj.email = username_or_email;
+    } else if (!hasUsernameErr) {
+      obj.username = username_or_email;
+    }
+    sanitizeData(obj);
+    await axios.post(`/api/notifications/`, obj);
   }
 };
 

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -186,7 +186,7 @@ export const startLogout = (cookies) => async (dispatch) => {
     await axios.delete(`/api/logout`);
     cookies.remove('user_id', {
       path: '/',
-      sameSite: 'None',
+      sameSite: 'none',
       secure: true,
     });
     dispatch(setRefreshTime(null));

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -408,10 +408,8 @@ export const attemptSendResetEmail = async (payload) => {
   const hasEmailErr = validateEmail(username_or_email);
   if (hasEmailErr && hasUsernameErr) {
     errors.usernameOrEmail = true;
-    console.error('dat error doe');
     throw errors;
   } else {
-    console.log('hooray!');
     const obj = {};
     if (!hasEmailErr) {
       obj.email = username_or_email;
@@ -453,6 +451,7 @@ export const attemptResetPassword = async (payload) => {
           password,
         })
       );
+      await resetPasswordResetInfo(uuid);
       return;
     }
   } catch (error) {
@@ -460,6 +459,23 @@ export const attemptResetPassword = async (payload) => {
     handleApiErrors(error.response, errors);
   }
   throw errors;
+};
+
+const resetPasswordResetInfo = async (id) => {
+  try {
+    const settingsRes = await axios.get(`/api/account_settings/${id}`);
+    const settings = settingsRes ? settingsRes.data : null;
+    if (settings) {
+      const updatedSettings = new SettingsReqBody({
+        ...settings,
+        password_reset_hash: null,
+        password_reset_time: null,
+      });
+      await axios.put(`/api/account_settings/${id}`, updatedSettings);
+    }
+  } catch (error) {
+    console.error(error);
+  }
 };
 
 export default userSlice.reducer;

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -416,7 +416,6 @@ export const attemptSendResetEmail = async (payload) => {
     } else if (!hasUsernameErr) {
       obj.username = username_or_email;
     }
-    sanitizeData(obj);
     await axios.post(`/api/notifications/`, obj);
   }
 };

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -423,4 +423,27 @@ export const attemptSendResetEmail = async (payload) => {
   }
 };
 
+export const getSettingsFromHash = async (hash) => {
+  const getSettingsRes = await axios.get(`/settings_from_reset_hash/${hash}`);
+  return getSettingsRes.data;
+};
+
+export const attemptResetPassword = async (payload) => {
+  const { password, retypePass, uuid } = payload;
+  const errors = {
+    password: validatePassword(password),
+    retypePass:
+      validatePassword(retypePass) || validatePassRetype(password, retypePass),
+  };
+
+  if (formHasNoErrors(errors)) {
+    await axios.patch(
+      `/api/accounts/${uuid}`,
+      new AccountReqBody({
+        password,
+      })
+    );
+  }
+};
+
 export default userSlice.reducer;

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -70,6 +70,7 @@ export const attemptLogin = (payload) => async (dispatch) => {
   };
   try {
     if (formHasNoErrors(errors)) {
+      sanitizeData(payload);
       const accountRes = await axios.post(`/api/auth/basic`, payload);
       const accountData = accountRes.data;
       const refreshTime = Date.now();

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -7,6 +7,7 @@ import {
   validateAlphaNumericUnicode,
   validatePassRetype,
   validateZipCode,
+  validateUsername,
   sanitizeData,
   formHasNoErrors,
 } from './helpers';
@@ -398,6 +399,20 @@ export const attemptUpdateAccount = (payload) => async (dispatch) => {
     }
   }
   throw errors;
+};
+
+export const attemptSendResetEmail = (payload) => {
+  const { username_or_email } = payload;
+  const errors = {};
+  const hasUsernameErr = validateUsername(username_or_email);
+  const hasEmailErr = validateEmail(username_or_email);
+  if (hasEmailErr && hasUsernameErr) {
+    errors.usernameOrEmail = true;
+    console.error('dat error doe');
+    throw errors;
+  } else {
+    console.log('hooray!');
+  }
 };
 
 export default userSlice.reducer;

--- a/client/src/store/user-slice/reset-password.js
+++ b/client/src/store/user-slice/reset-password.js
@@ -1,0 +1,87 @@
+import axios from 'axios';
+import { AccountReqBody, SettingsReqBody } from './classes';
+import {
+  validatePassword,
+  validateEmail,
+  validatePassRetype,
+  validateUsername,
+  sanitizeData,
+  formHasNoErrors,
+  handleApiErrors,
+} from './helpers';
+
+export const attemptSendResetEmail = async (payload) => {
+  const { username_or_email } = payload;
+  const errors = {};
+  const hasUsernameErr = validateUsername(username_or_email);
+  const hasEmailErr = validateEmail(username_or_email);
+  if (hasEmailErr && hasUsernameErr) {
+    errors.usernameOrEmail = 'Invalid username or e-mail';
+    throw errors;
+  } else {
+    const obj = {};
+    if (!hasEmailErr) {
+      obj.email = username_or_email;
+    } else if (!hasUsernameErr) {
+      obj.username = username_or_email;
+    }
+    await axios.post(`/api/notifications/`, obj);
+  }
+};
+
+export const getSettingsFromHash = async (hash) => {
+  const errors = {};
+  try {
+    const getSettingsRes = await axios.get(
+      `/api/settings_from_hash?pw_reset_hash=${hash}`
+    );
+    return getSettingsRes.data;
+  } catch (error) {
+    console.error(error);
+    handleApiErrors(error.response, errors);
+  }
+  throw errors;
+};
+
+export const attemptResetPassword = async (payload) => {
+  const { password, retypePass, uuid } = payload;
+  const errors = {
+    password: validatePassword(password),
+    retypePass: validatePassRetype(password, retypePass),
+  };
+  try {
+    if (formHasNoErrors(errors)) {
+      sanitizeData(password);
+      await axios.patch(
+        `/api/accounts/${uuid}`,
+        new AccountReqBody({
+          password,
+        })
+      );
+      await resetPasswordAndInfo(uuid);
+      return;
+    }
+  } catch (error) {
+    console.error(error);
+    handleApiErrors(error.response, errors);
+  }
+  throw errors;
+};
+
+const resetPasswordAndInfo = async (id) => {
+  try {
+    const settingsRes = await axios.get(`/api/account_settings/${id}`);
+    const settings = settingsRes ? settingsRes.data : null;
+    if (settings) {
+      const updatedSettings = new SettingsReqBody({
+        ...settings,
+        password_reset_hash: null,
+        password_reset_time: null,
+      });
+      await axios.put(`/api/account_settings/${id}`, updatedSettings);
+      await axios.delete(`/api/logout`);
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/client/src/styles/base.scss
+++ b/client/src/styles/base.scss
@@ -219,3 +219,10 @@ p {
   /* Gray 4 */
   color: $btnCyan;
 }
+
+.hover-hand-and-underline {
+  &:hover {
+    text-decoration: underline;
+    cursor: pointer;
+  }
+}

--- a/client/src/styles/base.scss
+++ b/client/src/styles/base.scss
@@ -221,6 +221,8 @@ p {
 }
 
 .hover-hand-and-underline {
+  display: inline;
+
   &:hover {
     text-decoration: underline;
     cursor: pointer;

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -107,7 +107,9 @@ CREATE TABLE public.account_settings (
     show_location boolean NOT NULL,
     organizers_can_see boolean NOT NULL,
     volunteers_can_see boolean NOT NULL,
-    initiative_map json NOT NULL
+    initiative_map json NOT NULL,
+    password_reset_hash text,
+    password_reset_time timestamp without time zone
 );
 
 
@@ -230,7 +232,7 @@ ALTER TABLE public.volunteer_openings OWNER TO admin;
 -- Data for Name: account_settings; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.account_settings (uuid, show_name, show_email, show_location, organizers_can_see, volunteers_can_see, initiative_map) FROM stdin;
+COPY public.account_settings (uuid, show_name, show_email, show_location, organizers_can_see, volunteers_can_see, initiative_map, password_reset_hash, password_reset_time) FROM stdin;
 \.
 
 

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -186,6 +186,7 @@ CREATE TABLE public.notifications (
     notification_uuid uuid NOT NULL,
     channel public.notificationchannel NOT NULL,
     recipient text NOT NULL,
+    subject text,
     message text NOT NULL,
     scheduled_send_date timestamp without time zone NOT NULL,
     status public.notificationstatus NOT NULL,
@@ -277,7 +278,7 @@ COPY public.initiatives (id, airtable_last_modified, updated_at, is_deleted, uui
 -- Data for Name: notifications; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.notifications (notification_uuid, channel, recipient, message, scheduled_send_date, status, send_date) FROM stdin;
+COPY public.notifications (notification_uuid, channel, recipient, subject, message, scheduled_send_date, status, send_date) FROM stdin;
 \.
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -108,7 +108,8 @@ CREATE TABLE public.account_settings (
     organizers_can_see boolean NOT NULL,
     volunteers_can_see boolean NOT NULL,
     initiative_map json NOT NULL,
-    password_reset_hash text
+    password_reset_hash text,
+    password_reset_time timestamp without time zone
 );
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -107,7 +107,8 @@ CREATE TABLE public.account_settings (
     show_location boolean NOT NULL,
     organizers_can_see boolean NOT NULL,
     volunteers_can_see boolean NOT NULL,
-    initiative_map json NOT NULL
+    initiative_map json NOT NULL,
+    password_reset_hash text
 );
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -186,6 +186,7 @@ CREATE TABLE public.notifications (
     notification_uuid uuid NOT NULL,
     channel public.notificationchannel NOT NULL,
     recipient text NOT NULL,
+    subject text,
     message text NOT NULL,
     scheduled_send_date timestamp without time zone NOT NULL,
     status public.notificationstatus NOT NULL,


### PR DESCRIPTION
Figured this was simple enough to implement over a weekend.
- modal to request a password reset is on the login page (can enter e-mail or username), changes view on successful submit
- user receives e-mail with URL including a hash param to reset password (expires in 15 minutes from request)
- after entering password, client lets user know reset was success and provides a link back to the login page