### PR TITLE
fixed oauth users not getting settings created on registration

### DIFF
--- a/api/account_api.py
+++ b/api/account_api.py
@@ -14,7 +14,6 @@ from starlette.middleware.sessions import SessionMiddleware
 from fastapi.responses import JSONResponse
 from fastapi_jwt_auth.exceptions import AuthJWTException
 from fastapi.encoders import jsonable_encoder
-# from auth import create_access_and_refresh_tokens
 from initiatives_api import GetAllInitiativeNames
 from settings import Config, Session, get_db
 from security import encrypt_password

--- a/client/src/__mocks__/api-data.js
+++ b/client/src/__mocks__/api-data.js
@@ -1,0 +1,44 @@
+export const mockInitiatives = [
+  {
+    uuid: '451ab264-262d-44f6-ab0d-e2b119f2bdd4',
+    external_id: '7694087271960',
+    initiative_name: 'Danielle Thomas',
+    order: 1,
+    details_url: 'http://www.white-chavez.com/',
+    hero_image_url: 'https://placeimg.com/901/15/any',
+    content:
+      'Camera system research personal personal here. Something finish receive study partner both field.',
+    role_ids: ['6861749069949', '8629011159341'],
+    event_ids: ['8118871313838', '4273169487982', '8135052026196'],
+    roles_count: 2,
+    events_count: 3,
+  },
+  {
+    uuid: '41adc192-b75a-44d7-8690-6a84deb01300',
+    external_id: '6539241697181',
+    initiative_name: 'Seth Pollard',
+    order: 2,
+    details_url: 'http://evans.com/app/tags/list/search.htm',
+    hero_image_url: 'https://placekitten.com/724/714',
+    content:
+      'Matter short man mean detail. Street end represent whole century between eye good. One most only voice story.',
+    role_ids: ['9718652962058', '5888786203885'],
+    event_ids: ['7326305020493', '5681041905711', '8242114729190'],
+    roles_count: 2,
+    events_count: 3,
+  },
+  {
+    uuid: 'c7f42e7b-960c-4b52-8956-3e330550e5ee',
+    external_id: '5192579170613',
+    initiative_name: 'Matthew Smith',
+    order: 3,
+    details_url: 'https://www.wade-pearson.org/tags/login/',
+    hero_image_url:
+      'https://actblue-indigo-uploads.s3.amazonaws.com/uploads/list-editor/brandings/65454/header/image_url/f7edc334-2217-43b9-b707-5b7eaed92c1b-logo_stacked.svg',
+    content: 'Her single hot security. Nearly two among figure piece.',
+    role_ids: ['8482888789772', '6976112891741'],
+    event_ids: ['8117927086726', '9881720466588', '4041284538489'],
+    roles_count: 2,
+    events_count: 3,
+  },
+];

--- a/client/src/__tests__/user-store.test.js
+++ b/client/src/__tests__/user-store.test.js
@@ -1,0 +1,85 @@
+import userReducer, { updateInitiativeMap } from 'store/user-slice';
+import axios from 'axios';
+import { mockInitiatives } from '../__mocks__/api-data';
+
+jest.mock('axios');
+console.log = jest.fn();
+console.error = jest.fn();
+
+describe('updateInitiativeMap function', () => {
+  it('can populate an existing initiative map with new values', async () => {
+    axios.get.mockImplementationOnce(() =>
+      Promise.resolve({ data: mockInitiatives })
+    );
+    const currentMap = { 'Seth Pollard': true };
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap['Danielle Thomas']).toBe(false);
+    expect(updatedMap['Seth Pollard']).toBe(true);
+    expect(updatedMap['Matthew Smith']).toBe(false);
+  });
+
+  it('can populate an empty initiative map with new values', async () => {
+    axios.get.mockImplementationOnce(() =>
+      Promise.resolve({ data: mockInitiatives })
+    );
+    const currentMap = null;
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap['Danielle Thomas']).toBe(false);
+    expect(updatedMap['Seth Pollard']).toBe(false);
+    expect(updatedMap['Matthew Smith']).toBe(false);
+  });
+
+  it('can leave an initiative map alone if it already contains updated values', async () => {
+    axios.get.mockImplementationOnce(() =>
+      Promise.resolve({ data: mockInitiatives })
+    );
+    const currentMap = {
+      'Danielle Thomas': false,
+      'Seth Pollard': true,
+      'Matthew Smith': true,
+    };
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap).toMatchObject(currentMap);
+  });
+
+  it('can return an empty object if the initiatives API endpiont returns an empty array', async () => {
+    axios.get.mockImplementationOnce(() => Promise.resolve({ data: [] }));
+    const currentMap = {
+      'Danielle Thomas': false,
+      'Seth Pollard': true,
+      'Matthew Smith': true,
+    };
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap).toMatchObject({});
+  });
+
+  it('can return the input payload if the initiatives API endpoint throws an error', async () => {
+    axios.get.mockImplementationOnce(() => Promise.reject('some mock error'));
+    const currentMap = {
+      'Danielle Thomas': false,
+      'Seth Pollard': true,
+      'Matthew Smith': true,
+    };
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap).toMatchObject(currentMap);
+  });
+
+  it('can return an empty object if the input payload is null and the initiatives API endpoint throws an error', async () => {
+    axios.get.mockImplementationOnce(() => Promise.reject('some mock error'));
+    const currentMap = null;
+    const updatedMap = await updateInitiativeMap(currentMap);
+
+    expect(updatedMap).toBeDefined();
+    expect(updatedMap).toMatchObject({});
+  });
+});

--- a/client/src/pages/account/Involvement.js
+++ b/client/src/pages/account/Involvement.js
@@ -59,41 +59,43 @@ function Involvement(props) {
       );
     }
 
-    Object.entries(user.initiative_map).forEach(
-      ([initiative_name, isSubscribed]) => {
-        initiativesToRender.push(
-          <Row className="mt-2 mb-2" key={'initiative-' + initiative_name}>
-            <Col xs={12} md={8}>
-              <Form.Group>
-                <Form.Control type="name" value={initiative_name} readOnly />
-              </Form.Group>
-            </Col>
-            <Col xs={12} md={4}>
-              <Row>
-                <Col xs={8} sm={7} md={12} className="d-md-none">
-                  <label className="text-muted ml-lg-5">Subscribed</label>
-                </Col>
-                <Col xs={4} sm={5} md={12}>
-                  <Form.Switch
-                    id={'involvement-initiative-' + initiative_name}
-                    className="custom-switch-md ml-lg-5 text-md-center"
-                    checked={isSubscribed}
-                    onChange={() =>
-                      toggleInitiativeSubscription({
-                        user,
-                        initiative_name,
-                        isSubscribed,
-                        tokenRefreshTime,
-                      })
-                    }
-                  />
-                </Col>
-              </Row>
-            </Col>
-          </Row>
-        );
-      }
-    );
+    if (user.initiative_map) {
+      Object.entries(user.initiative_map).forEach(
+        ([initiative_name, isSubscribed]) => {
+          initiativesToRender.push(
+            <Row className="mt-2 mb-2" key={'initiative-' + initiative_name}>
+              <Col xs={12} md={8}>
+                <Form.Group>
+                  <Form.Control type="name" value={initiative_name} readOnly />
+                </Form.Group>
+              </Col>
+              <Col xs={12} md={4}>
+                <Row>
+                  <Col xs={8} sm={7} md={12} className="d-md-none">
+                    <label className="text-muted ml-lg-5">Subscribed</label>
+                  </Col>
+                  <Col xs={4} sm={5} md={12}>
+                    <Form.Switch
+                      id={'involvement-initiative-' + initiative_name}
+                      className="custom-switch-md ml-lg-5 text-md-center"
+                      checked={isSubscribed}
+                      onChange={() =>
+                        toggleInitiativeSubscription({
+                          user,
+                          initiative_name,
+                          isSubscribed,
+                          tokenRefreshTime,
+                        })
+                      }
+                    />
+                  </Col>
+                </Row>
+              </Col>
+            </Row>
+          );
+        }
+      );
+    }
   }
   return user ? (
     <>

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -37,6 +37,7 @@ const userSlice = createSlice({
       state.user = null;
       state.firstAcctPage = null;
       state.tokenRefreshTime = null;
+      state.initLoading = false;
     },
     setFirstAcctPage: (state, action) => {
       const { payload } = action;
@@ -96,21 +97,28 @@ const getSettings = async (id) => {
 
   try {
     const getRes = await axios.get(`/api/account_settings/${id}`);
-    return getRes.data;
+    const settings = getRes.data;
+    if (settings) {
+      settings.initiative_map = await updateInitiativeMap(
+        settings.initiative_map
+      );
+    }
+    return settings;
   } catch (error) {
     console.error(error);
   }
 };
 
-const updateInitiativeMap = async (initiative_map = {}) => {
+const updateInitiativeMap = async (initiative_map) => {
   const initiativeResponse = await axios.get(`/api/initiatives/`);
   const updatedMap = {};
   const initiatives = initiativeResponse.data;
 
   if (initiatives && initiatives.length) {
     initiatives.forEach((item) => {
-      updatedMap[item.initiative_name] =
-        initiative_map[item.initiative_name] || false;
+      updatedMap[item.initiative_name] = initiative_map
+        ? initiative_map[item.initiative_name]
+        : false;
     });
   }
   return updatedMap;
@@ -276,10 +284,10 @@ export const deleteUser = (uuid, cookies) => async (dispatch) => {
     await refreshAccessToken();
     await axios.delete(`/api/accounts/${uuid}`);
     cookies.remove('user_id', { path: '/', sameSite: 'None', secure: true });
-    dispatch(completeLogout());
   } catch (error) {
     console.error(error);
-    handlePossibleExpiredToken(error);
+  } finally {
+    dispatch(completeLogout());
   }
 };
 

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -109,19 +109,25 @@ const getSettings = async (id) => {
   }
 };
 
-const updateInitiativeMap = async (initiative_map) => {
-  const initiativeResponse = await axios.get(`/api/initiatives/`);
+export const updateInitiativeMap = async (payload) => {
+  const initiative_map = payload ?? {};
   const updatedMap = {};
-  const initiatives = initiativeResponse.data;
 
-  if (initiatives && initiatives.length) {
-    initiatives.forEach((item) => {
-      updatedMap[item.initiative_name] = initiative_map
-        ? initiative_map[item.initiative_name]
-        : false;
-    });
+  try {
+    const initiativeResponse = await axios.get(`/api/initiatives/`);
+    const initiatives = initiativeResponse.data;
+
+    if (initiatives) {
+      initiatives.forEach((item) => {
+        updatedMap[item.initiative_name] =
+          initiative_map[item.initiative_name] ?? false;
+      });
+    }
+    return updatedMap;
+  } catch {
+    console.error('error while attempting to update initiative map');
+    return initiative_map;
   }
-  return updatedMap;
 };
 
 export const checkIfCookieIsValid = (cookies) => async (dispatch) => {


### PR DESCRIPTION
Follow-up to #112 

Settings were turning up null. The involvement page wasn't properly handling empty settings either.