### PR TITLE
Adding account registration confirmation e-mail for basic auth accounts

### DIFF
--- a/api/account_api.py
+++ b/api/account_api.py
@@ -51,7 +51,7 @@ def create_access_and_refresh_tokens(user_id: str, Authorize: AuthJWT):
 
 def check_valid_password(password: str):
     match = re.search(
-        "^.*(?=.*\d)(?=.*[a-zA-Z])(?=.*\d)(?=.*[`!@#$%^&*()_+\-=[\]{};':\"\\|,.<>/?~]).{6,20}$", password)
+        r"^.*(?=.*\d)(?=.*[a-zA-Z])(?=.*\d)(?=.*[`!@#$%^&*()_+\-=[\]{};':\"\\|,.<>/?~]).{6,20}$", password)
     if match is None:
         raise HTTPException(status_code=400,
                             detail=f"Please enter a password between 6 and 20 characters long with at least 1 letter, 1 number, and 1 special character.")

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -28,14 +28,14 @@ router = APIRouter()
 # However, they're useful to have when running locally for debugging purposes
 
 
-@router.get("/accounts/", response_model=List[AccountResponseSchema])
-def get_all_accounts(db: Session = Depends(get_db)):
-    return db.query(Account).all()
+# @router.get("/accounts/", response_model=List[AccountResponseSchema])
+# def get_all_accounts(db: Session = Depends(get_db)):
+#     return db.query(Account).all()
 
 
-@router.get("/account_settings/", status_code=200)
-def get_all_account_settings(db: Session = Depends(get_db)):
-    return db.query(AccountSettings).all()
+# @router.get("/account_settings/", status_code=200)
+# def get_all_account_settings(db: Session = Depends(get_db)):
+#     return db.query(AccountSettings).all()
 
 
 def create_access_and_refresh_tokens(user_id: str, Authorize: AuthJWT):

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -1,18 +1,12 @@
 from fastapi import Depends, FastAPI, Form, Request, HTTPException, Header, APIRouter
-from fastapi.middleware.cors import CORSMiddleware
 from typing import List, Optional, Text, Union, Mapping, Any
 from models import Account, AccountSettings
-from schemas import (AccountCreateRequestSchema, AccountResponseSchema,
-                     AccountNewPasswordSchema, AccountSettingsSchema, AccountBaseSchema)
-from models.notification import Notification, NotificationChannel, NotificationStatus
 import notifications_manager as nm
 from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
                      AccountNewPasswordSchema, AccountSettingsSchema, AccountNotificationSchema)
 from sqlalchemy import or_
 from sqlalchemy.orm import lazyload
 from starlette.middleware.sessions import SessionMiddleware
-from fastapi.responses import JSONResponse
-from fastapi_jwt_auth.exceptions import AuthJWTException
 from fastapi.encoders import jsonable_encoder
 from initiatives_api import GetAllInitiativeNames
 from settings import Config, Session, get_db
@@ -42,11 +36,6 @@ router = APIRouter()
 # @router.get("/account_settings/", status_code=200)
 # def get_all_account_settings(db: Session = Depends(get_db)):
 #     return db.query(AccountSettings).all()
-
-
-# @router.get("/notifications/", status_code=200)
-# def get_all_notifications(db: Session = Depends(get_db)):
-#     return db.query(Notification).all()
 
 
 def create_access_and_refresh_tokens(user_id: str, Authorize: AuthJWT):
@@ -204,129 +193,3 @@ def update_settings(uuid, settings: AccountSettingsSchema, Authorize: AuthJWT = 
     db.merge(updated_settings)
     db.commit()
     return updated_settings
-
-
-@router.post("/notifications/", status_code=204)
-def create_notification(notification_payload: AccountNotificationSchema, db: Session = Depends(get_db)):
-    existing_acct = None
-    if notification_payload.email is not None:
-        existing_acct = db.query(Account).filter_by(
-            email=notification_payload.email).first() or db.query(Account).filter_by(
-                email=sanitize_email(notification_payload.email)).first()
-    elif notification_payload.username is not None:
-        existing_acct = db.query(Account).filter_by(
-            username=notification_payload.username.strip()).first()
-    create_email(notification_payload, existing_acct, db)
-
-
-def create_email(notification_payload: AccountNotificationSchema, existing_acct: Account, db: Session):
-    email_message = None
-    if existing_acct is not None:
-        if notification_payload.notification_type == 'password_reset':
-            email_message = f'<p>Dear {existing_acct.first_name},</p>'
-            if existing_acct.oauth is None:
-                base_url = Config['routes']['client']
-                acct_settings = db.query(AccountSettings).filter_by(
-                    uuid=existing_acct.uuid).first()
-                curr_time = datetime.now()
-                password_reset_hash = generate_str_for_hash(
-                    existing_acct.username, curr_time)
-                acct_settings.password_reset_hash = password_reset_hash
-                acct_settings.password_reset_time = curr_time
-                db.merge(acct_settings)
-                db.commit()
-
-                url_to_click = f'{base_url}/reset_password?hash={password_reset_hash}'
-                email_message += f'<p>We have received a request to reset your password. To reset your password, \
-                        please click the following link: <a href="{url_to_click}">change my password</a></p> \
-                        <p>This link will expire in 15 minutes.</p>'
-            else:
-                oauth_type = existing_acct.oauth.capitalize()
-                email_message += f'<p>We have received a request to reset your password. \
-                    Your account was created with {oauth_type} OAuth; therefore, \
-                    you cannot set or reset a password. \
-                    Please try signing in with {oauth_type}.</p>'
-            email_message += '<b>If this action was not performed by you, \
-                    someone may be targeting your account. You may want to consider changing your e-mail password. </b>\
-                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
-            nm.send_notification(recipient=existing_acct.email, message=email_message,
-                                 channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Password Reset')
-        elif notification_payload.notification_type == 'verify_registration':
-            base_url = Config['routes']['client']
-            acct_settings = db.query(AccountSettings).filter_by(
-                uuid=existing_acct.uuid).first()
-            curr_time = datetime.now()
-            verify_account_hash = generate_str_for_hash(
-                existing_acct.username, curr_time)
-            acct_settings.verify_account_hash = verify_account_hash
-            db.merge(acct_settings)
-            db.commit()
-
-            verify_url = f'{base_url}/verify_account?hash={verify_account_hash}'
-            cancel_url = f'{base_url}/cancel_registration?hash={verify_account_hash}'
-
-            email_message = f'<p>Dear {existing_acct.first_name},</p>'
-            email_message += f'<p>We have received a request to create an account. Accounts not created with OAuth require \
-                        e-mail verification. Please click the following link: <a href="{verify_url}">verify my account</a></p>'
-            email_message += f'<b>If this action was not performed by you or performed by accident, \
-                    you may click the following link to undo account creation: <a href="{cancel_url}">undo account registration</a></b>\
-                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
-            nm.send_notification(recipient=existing_acct.email, message=email_message,
-                                 channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Account Registration')
-
-
-@router.get("/settings_from_hash", status_code=200)
-def get_settings_from_hash(pw_reset_hash: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
-    existing_settings = db.query(AccountSettings).filter_by(
-        password_reset_hash=pw_reset_hash).first()
-    if existing_settings is not None:
-        time_diff = minutes_difference(existing_settings.password_reset_time)
-        if time_diff >= 15:
-            existing_settings.password_reset_hash = None
-            existing_settings.password_reset_time = None
-            db.merge(existing_settings)
-            db.commit()
-            raise HTTPException(status_code=400,
-                                detail=f"Invalid or expired password reset URL!")
-        else:
-            create_access_and_refresh_tokens(
-                str(existing_settings.uuid), Authorize)
-            return existing_settings
-    else:
-        raise HTTPException(status_code=400,
-                            detail=f"Invalid or expired password reset URL!")
-
-
-@router.get("/verify_account_from_hash", status_code=200)
-def complete_account_registration(verify_hash: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
-    existing_settings = db.query(AccountSettings).filter_by(
-        verify_account_hash=verify_hash).first()
-    if existing_settings is not None:
-        existing_settings.verify_account_hash = None
-        db.merge(existing_settings)
-        db.commit()
-        existing_account = db.query(Account).filter_by(
-            uuid=existing_settings.uuid).first()
-        if existing_account is not None:
-            existing_account.is_verified = True
-            db.merge(existing_account)
-            db.commit()
-    else:
-        raise HTTPException(status_code=400,
-                            detail=f"invalid hash or account does not exist")
-
-
-def generate_str_for_hash(username: str, curr_time: datetime):
-    one_rand_num = random.uniform(1, 101)
-    password_reset_hash = encrypt_password(
-        username +
-        str(curr_time) + str(random.uniform(1, one_rand_num)
-                             + random.uniform(1, one_rand_num) + random.uniform(1, one_rand_num)))
-    return password_reset_hash
-
-
-def minutes_difference(reset_req_time: datetime):
-    curr_time = datetime.now()
-    seconds_diff = abs((curr_time - reset_req_time).seconds)
-    minutes_diff = seconds_diff/60
-    return minutes_diff

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -28,14 +28,14 @@ router = APIRouter()
 # However, they're useful to have when running locally for debugging purposes
 
 
-# @router.get("/accounts/", response_model=List[AccountResponseSchema])
-# def get_all_accounts(db: Session = Depends(get_db)):
-#     return db.query(Account).all()
+@router.get("/accounts/", response_model=List[AccountResponseSchema])
+def get_all_accounts(db: Session = Depends(get_db)):
+    return db.query(Account).all()
 
 
-# @router.get("/account_settings/", status_code=200)
-# def get_all_account_settings(db: Session = Depends(get_db)):
-#     return db.query(AccountSettings).all()
+@router.get("/account_settings/", status_code=200)
+def get_all_account_settings(db: Session = Depends(get_db)):
+    return db.query(AccountSettings).all()
 
 
 def create_access_and_refresh_tokens(user_id: str, Authorize: AuthJWT):

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -7,7 +7,7 @@ from schemas import (AccountCreateRequestSchema, AccountResponseSchema,
 from models.notification import Notification, NotificationChannel, NotificationStatus
 import notifications_manager as nm
 from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
-                     AccountNewPasswordSchema, AccountSettingsSchema, AcctUsernameOrEmailSchema)
+                     AccountNewPasswordSchema, AccountSettingsSchema, AccountNotificationSchema)
 from sqlalchemy import or_
 from sqlalchemy.orm import lazyload
 from starlette.middleware.sessions import SessionMiddleware
@@ -207,15 +207,15 @@ def update_settings(uuid, settings: AccountSettingsSchema, Authorize: AuthJWT = 
 
 
 @router.post("/notifications/", status_code=204)
-def create_notification(username_or_email: AcctUsernameOrEmailSchema, db: Session = Depends(get_db)):
+def create_notification(notification_payload: AccountNotificationSchema, db: Session = Depends(get_db)):
     existing_acct = None
-    if username_or_email.email is not None:
+    if notification_payload.email is not None:
         existing_acct = db.query(Account).filter_by(
-            email=username_or_email.email).first() or db.query(Account).filter_by(
-                email=sanitize_email(username_or_email.email)).first()
-    elif username_or_email.username is not None:
+            email=notification_payload.email).first() or db.query(Account).filter_by(
+                email=sanitize_email(notification_payload.email)).first()
+    elif notification_payload.username is not None:
         existing_acct = db.query(Account).filter_by(
-            username=username_or_email.username.strip()).first()
+            username=notification_payload.username.strip()).first()
 
     email_message = None
     if existing_acct is not None:

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -157,19 +157,27 @@ def update_password(uuid, partial_account: AccountNewPasswordSchema, Authorize: 
 
 
 @router.delete("/accounts/{uuid}", status_code=204)
-def delete_account(uuid, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+def remove_user(uuid, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
     Authorize.jwt_required()
     check_matching_user(uuid, Authorize)
+    delete_user(uuid, db)
+
+
+def delete_user(uuid: UUID, db):
+    delete_settings(uuid, db)
+    delete_account(uuid, db)
+
+
+def delete_account(uuid: UUID, db: Session):
     acct_to_delete = db.query(Account).filter_by(uuid=uuid).first()
     if acct_to_delete is None:
         raise HTTPException(status_code=400,
                             detail=f"Account with UUID {uuid} not found")
     db.delete(acct_to_delete)
     db.commit()
-    delete_settings(uuid, db)
 
 
-def delete_settings(uuid, db):
+def delete_settings(uuid: UUID, db: Session):
     settings_to_delete = db.query(AccountSettings).filter_by(uuid=uuid).first()
     if settings_to_delete is None:
         raise HTTPException(status_code=400,

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -1,16 +1,13 @@
 from fastapi import Depends, FastAPI, Form, Request, HTTPException, Header, APIRouter
 from typing import List, Optional, Text, Union, Mapping, Any
 from models import Account, AccountSettings
-import notifications_manager as nm
 from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
                      AccountNewPasswordSchema, AccountSettingsSchema, AccountNotificationSchema)
-from sqlalchemy import or_
 from sqlalchemy.orm import lazyload
 from starlette.middleware.sessions import SessionMiddleware
 from fastapi.encoders import jsonable_encoder
 from initiatives_api import GetAllInitiativeNames
 from settings import Config, Session, get_db
-from security import encrypt_password
 import logging
 from uuid import uuid4, UUID
 from fastapi_jwt_auth import AuthJWT
@@ -18,9 +15,6 @@ import external_data_sync
 from security import encrypt_password, check_encrypted_password
 import re
 from datetime import datetime
-import socket
-import random
-import decimal
 from helpers import sanitize_email
 router = APIRouter()
 
@@ -163,7 +157,7 @@ def remove_user(uuid, Authorize: AuthJWT = Depends(), db: Session = Depends(get_
     delete_user(uuid, db)
 
 
-def delete_user(uuid: UUID, db):
+def delete_user(uuid: UUID, db: Session):
     delete_settings(uuid, db)
     delete_account(uuid, db)
 

--- a/api/api.py
+++ b/api/api.py
@@ -11,6 +11,7 @@ from fastapi.encoders import jsonable_encoder
 import auth
 import account_api
 import initiatives_api
+import notifications_api
 from settings import Config, Session, get_db
 import logging
 from uuid import uuid4, UUID
@@ -41,6 +42,10 @@ app.include_router(
 )
 app.include_router(
     initiatives_api.router,
+    prefix='/api'
+)
+app.include_router(
+    notifications_api.router,
     prefix='/api'
 )
 

--- a/api/auth.py
+++ b/api/auth.py
@@ -86,7 +86,8 @@ async def authorize_google(request: Request, Authorize: AuthJWT = Depends(), db:
             first_name=user.given_name,
             last_name=user.family_name,
             oauth='google',
-            profile_pic=user.picture
+            profile_pic=user.picture,
+            is_verified=True,
         )
         db.add(new_account)
         db.commit()
@@ -126,6 +127,10 @@ def authorize_basic(account: AccountBasicLoginSchema, Authorize: AuthJWT = Depen
     if verified_pw is False:
         raise HTTPException(
             status_code=403, detail=f"Password is incorrect")
+    if existing_acct.is_verified is False:
+        raise HTTPException(
+            status_code=403, detail=f"Account has not been verified. Please check your e-mail."
+        )
     create_access_and_refresh_tokens(str(existing_acct.uuid), Authorize)
     return existing_acct
 
@@ -176,6 +181,7 @@ async def authorize_github(request: Request, Authorize: AuthJWT = Depends(), db:
                 0],
             state=None if user['location'] is None else user['location'].split(', ')[
                 1],
+            is_verified=True
         )
         db.add(new_account)
         db.commit()

--- a/api/auth.py
+++ b/api/auth.py
@@ -121,12 +121,12 @@ def authorize_basic(account: AccountBasicLoginSchema, Authorize: AuthJWT = Depen
     existing_acct = db.query(Account).filter_by(email=account.email).first()
     if existing_acct is None:
         raise HTTPException(
-            status_code=400, detail=f"An account with the email address {account.email} does not exist")
+            status_code=403, detail=f"E-mail or password is invalid!")
     verified_pw = check_encrypted_password(
         account.password, existing_acct.password)
     if verified_pw is False:
         raise HTTPException(
-            status_code=403, detail=f"Password is incorrect")
+            status_code=403, detail=f"E-mail or password is invalid!")
     if existing_acct.is_verified is False:
         raise HTTPException(
             status_code=403, detail=f"Account has not been verified. Please check your e-mail."

--- a/api/helpers.py
+++ b/api/helpers.py
@@ -20,3 +20,7 @@ def sanitize_data(payload):
             continue
         else:
             payload[key] = trim_str(payload[key])
+
+
+def row2dict(row):
+    return dict((col, getattr(row, col)) for col in row.__table__.columns.keys())

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -27,7 +27,8 @@ class Account(Base):
     state = Column('state', String(32), nullable=True)
     roles = Column('roles', ARRAY(String), default=[], nullable=False)
     zip_code = Column('zip_code', String(32), nullable=True)
+    is_verified = Column('is_verified', Boolean, default=False, nullable=False)
 
     def __repr__(self):
-        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', last_name='%s', password='%s', oauth='%s', profile_pic='%s', city='%s', state='%s', zip_code='%s', roles='%s')>" % (
-            self.uuid, self.email, self.username, self.first_name, self.last_name, self.password, self.oauth, self.profile_pic, self.city, self.state, self.zip_code, self.roles)
+        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', last_name='%s', password='%s', oauth='%s', profile_pic='%s', city='%s', state='%s', zip_code='%s', roles='%s', is_verified='%s')>" % (
+            self.uuid, self.email, self.username, self.first_name, self.last_name, self.password, self.oauth, self.profile_pic, self.city, self.state, self.zip_code, self.roles, self.is_verified)

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -28,6 +28,8 @@ class AccountSettings(Base):
     password_reset_time = Column(
         'password_reset_time', DateTime, nullable=True)
     verify_account_hash = Column('verify_account_hash', Text, nullable=True)
+    cancel_registration_hash = Column(
+        'cancel_registration_hash', Text, nullable=True)
 
     def __repr__(self):
         return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s', password_reset_time='%s')>" % (

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -27,6 +27,7 @@ class AccountSettings(Base):
     password_reset_hash = Column('password_reset_hash', Text, nullable=True)
     password_reset_time = Column(
         'password_reset_time', DateTime, nullable=True)
+    verify_account_hash = Column('password_reset_hash', Text, nullable=True)
 
     def __repr__(self):
         return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s', password_reset_time='%s')>" % (

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -27,7 +27,7 @@ class AccountSettings(Base):
     password_reset_hash = Column('password_reset_hash', Text, nullable=True)
     password_reset_time = Column(
         'password_reset_time', DateTime, nullable=True)
-    verify_account_hash = Column('password_reset_hash', Text, nullable=True)
+    verify_account_hash = Column('verify_account_hash', Text, nullable=True)
 
     def __repr__(self):
         return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s', password_reset_time='%s')>" % (

--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -126,6 +126,7 @@ def complete_account_registration(verify_hash: str, Authorize: AuthJWT = Depends
     if settings is not None:
         acct_uuid = settings.uuid
         settings.verify_account_hash = None
+        settings.cancel_registration_hash = None
         db.merge(settings)
         db.commit()
         account = db.query(Account).filter_by(
@@ -144,8 +145,8 @@ def complete_account_registration(verify_hash: str, Authorize: AuthJWT = Depends
                             detail=f"invalid hash or account does not exist")
 
 
-@router.delete("/cancel_registration", status_code=204)
-def delete_account_from_hash(cancel_hash: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+@router.delete("/cancel_registration_from_hash", status_code=204)
+def cancel_account_registration(cancel_hash: str, db: Session = Depends(get_db)):
     settings_to_delete = db.query(AccountSettings).filter_by(
         cancel_registration_hash=cancel_hash).first()
     if settings_to_delete is None:

--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -14,7 +14,7 @@ import socket
 import random
 import decimal
 from helpers import sanitize_email, row2dict
-from account_api import create_access_and_refresh_tokens
+from account_api import create_access_and_refresh_tokens, delete_user
 router = APIRouter()
 
 # @router.get("/notifications/", status_code=200)
@@ -153,10 +153,7 @@ def cancel_account_registration(cancel_hash: str, db: Session = Depends(get_db))
         raise HTTPException(status_code=400,
                             detail=f"Account settings with hash {cancel_hash} not found")
     acct_uuid = settings_to_delete.uuid
-    acct_to_delete = db.query(Account).filter_by(uuid=acct_uuid).first()
-    db.delete(settings_to_delete)
-    db.delete(acct_to_delete)
-    db.commit()
+    delete_user(acct_uuid, db)
 
 
 def generate_str_for_hash(username: str, curr_time: datetime):

--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -32,6 +32,9 @@ def create_notification(notification_payload: AccountNotificationSchema, db: Ses
     elif notification_payload.username is not None:
         existing_acct = db.query(Account).filter_by(
             username=notification_payload.username.strip()).first()
+    else:
+        raise HTTPException(status_code=400,
+                            detail=f"Invalid username or e-mail!")
     create_and_send_email(notification_payload, existing_acct, db)
 
 

--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -1,0 +1,148 @@
+from fastapi import Depends, FastAPI, Form, Request, HTTPException, Header, APIRouter
+from typing import List, Optional, Text, Union, Mapping, Any
+from models import Account, AccountSettings
+from models.notification import Notification, NotificationChannel, NotificationStatus
+import notifications_manager as nm
+from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
+                     AccountNewPasswordSchema, AccountSettingsSchema, AccountNotificationSchema)
+from settings import Config, Session, get_db
+from uuid import uuid4, UUID
+from fastapi_jwt_auth import AuthJWT
+from security import encrypt_password, check_encrypted_password
+from datetime import datetime
+import socket
+import random
+import decimal
+from helpers import sanitize_email
+from account_api import create_access_and_refresh_tokens
+router = APIRouter()
+
+# @router.get("/notifications/", status_code=200)
+# def get_all_notifications(db: Session = Depends(get_db)):
+#     return db.query(Notification).all()
+
+
+@router.post("/notifications/", status_code=204)
+def create_notification(notification_payload: AccountNotificationSchema, db: Session = Depends(get_db)):
+    existing_acct = None
+    if notification_payload.email is not None:
+        existing_acct = db.query(Account).filter_by(
+            email=notification_payload.email).first() or db.query(Account).filter_by(
+                email=sanitize_email(notification_payload.email)).first()
+    elif notification_payload.username is not None:
+        existing_acct = db.query(Account).filter_by(
+            username=notification_payload.username.strip()).first()
+    create_email(notification_payload, existing_acct, db)
+
+
+def create_email(notification_payload: AccountNotificationSchema, existing_acct: Account, db: Session):
+    email_message = None
+    if existing_acct is not None:
+        if notification_payload.notification_type == 'password_reset':
+            email_message = f'<p>Dear {existing_acct.first_name},</p>'
+            if existing_acct.oauth is None:
+                base_url = Config['routes']['client']
+                acct_settings = db.query(AccountSettings).filter_by(
+                    uuid=existing_acct.uuid).first()
+                curr_time = datetime.now()
+                password_reset_hash = generate_str_for_hash(
+                    existing_acct.username, curr_time)
+                acct_settings.password_reset_hash = password_reset_hash
+                acct_settings.password_reset_time = curr_time
+                db.merge(acct_settings)
+                db.commit()
+
+                url_to_click = f'{base_url}/reset_password?hash={password_reset_hash}'
+                email_message += f'<p>We have received a request to reset your password. To reset your password, \
+                        please click the following link: <a href="{url_to_click}">change my password</a></p> \
+                        <p>This link will expire in 15 minutes.</p>'
+            else:
+                oauth_type = existing_acct.oauth.capitalize()
+                email_message += f'<p>We have received a request to reset your password. \
+                    Your account was created with {oauth_type} OAuth; therefore, \
+                    you cannot set or reset a password. \
+                    Please try signing in with {oauth_type}.</p>'
+            email_message += '<b>If this action was not performed by you, \
+                    someone may be targeting your account. You may want to consider changing your e-mail password. </b>\
+                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
+            nm.send_notification(recipient=existing_acct.email, message=email_message,
+                                 channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Password Reset')
+        elif notification_payload.notification_type == 'verify_registration':
+            base_url = Config['routes']['client']
+            acct_settings = db.query(AccountSettings).filter_by(
+                uuid=existing_acct.uuid).first()
+            curr_time = datetime.now()
+            verify_account_hash = generate_str_for_hash(
+                existing_acct.username, curr_time)
+            acct_settings.verify_account_hash = verify_account_hash
+            db.merge(acct_settings)
+            db.commit()
+
+            verify_url = f'{base_url}/verify_account?hash={verify_account_hash}'
+            cancel_url = f'{base_url}/cancel_registration?hash={verify_account_hash}'
+
+            email_message = f'<p>Dear {existing_acct.first_name},</p>'
+            email_message += f'<p>We have received a request to create an account. Accounts not created with OAuth require \
+                        e-mail verification. Please click the following link: <a href="{verify_url}">verify my account</a></p>'
+            email_message += f'<b>If this action was not performed by you or performed by accident, \
+                    you may click the following link to undo account creation: <a href="{cancel_url}">undo account registration</a></b>\
+                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
+            nm.send_notification(recipient=existing_acct.email, message=email_message,
+                                 channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Account Registration')
+
+
+@router.get("/settings_from_hash", status_code=200)
+def get_settings_from_hash(pw_reset_hash: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+    existing_settings = db.query(AccountSettings).filter_by(
+        password_reset_hash=pw_reset_hash).first()
+    if existing_settings is not None:
+        time_diff = minutes_difference(existing_settings.password_reset_time)
+        if time_diff >= 15:
+            existing_settings.password_reset_hash = None
+            existing_settings.password_reset_time = None
+            db.merge(existing_settings)
+            db.commit()
+            raise HTTPException(status_code=400,
+                                detail=f"Invalid or expired password reset URL!")
+        else:
+            create_access_and_refresh_tokens(
+                str(existing_settings.uuid), Authorize)
+            return existing_settings
+    else:
+        raise HTTPException(status_code=400,
+                            detail=f"Invalid or expired password reset URL!")
+
+
+@router.get("/verify_account_from_hash", status_code=200)
+def complete_account_registration(verify_hash: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+    existing_settings = db.query(AccountSettings).filter_by(
+        verify_account_hash=verify_hash).first()
+    if existing_settings is not None:
+        existing_settings.verify_account_hash = None
+        db.merge(existing_settings)
+        db.commit()
+        existing_account = db.query(Account).filter_by(
+            uuid=existing_settings.uuid).first()
+        if existing_account is not None:
+            existing_account.is_verified = True
+            db.merge(existing_account)
+            db.commit()
+    else:
+        raise HTTPException(status_code=400,
+                            detail=f"invalid hash or account does not exist")
+
+
+def generate_str_for_hash(username: str, curr_time: datetime):
+    one_rand_num = random.uniform(1, 101)
+    password_reset_hash = encrypt_password(
+        username +
+        str(curr_time) + str(random.uniform(1, one_rand_num)
+                             + random.uniform(1, one_rand_num) + random.uniform(1, one_rand_num)))
+    return password_reset_hash
+
+
+def minutes_difference(reset_req_time: datetime):
+    curr_time = datetime.now()
+    seconds_diff = abs((curr_time - reset_req_time).seconds)
+    minutes_diff = seconds_diff/60
+    return minutes_diff

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -2,5 +2,5 @@ from schemas.initiative import InitiativeSchema, NestedInitiativeSchema
 from schemas.volunteer_event import VolunteerEventSchema
 from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
-                             AccountBasicLoginSchema, AccountPasswordSchema, AccountNewPasswordSchema, AcctUsernameOrEmailSchema)
+                             AccountBasicLoginSchema, AccountPasswordSchema, AccountNewPasswordSchema, AccountNotificationSchema)
 from schemas.account_settings import AccountSettingsSchema

--- a/api/schemas/account.py
+++ b/api/schemas/account.py
@@ -45,3 +45,4 @@ class AccountNewPasswordSchema(BaseModel):
 class AccountNotificationSchema(BaseModel):
     username: Optional[str]
     email: Optional[str]
+    notification_type: str

--- a/api/schemas/account.py
+++ b/api/schemas/account.py
@@ -14,12 +14,15 @@ class AccountBaseSchema(BaseModel):
     state: Optional[str]
     zip_code: Optional[str]
     roles: Optional[List]
+    is_verified: Optional[bool]
 
     class Config:
         orm_mode = True
 
+
 class AccountCreateRequestSchema(AccountBaseSchema):
     password: Text
+
 
 class AccountResponseSchema(AccountBaseSchema):
     uuid: UUID
@@ -39,6 +42,6 @@ class AccountNewPasswordSchema(BaseModel):
     password: Text
 
 
-class AcctUsernameOrEmailSchema(BaseModel):
+class AccountNotificationSchema(BaseModel):
     username: Optional[str]
     email: Optional[str]

--- a/api/schemas/account_settings.py
+++ b/api/schemas/account_settings.py
@@ -14,6 +14,8 @@ class AccountSettingsSchema(BaseModel):
     initiative_map: Dict
     password_reset_hash: Optional[Text]
     password_reset_time: Optional[datetime]
+    verify_account_hash: Optional[Text]
+    cancel_registration_hash: Optional[Text]
 
     class Config:
         orm_mode = True

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -223,7 +223,8 @@ def test_account_settings_update(db):
 @patch('notifications_manager.email_client.send')
 def test_account_password_reset_notification(mock_send, db):
     # no notification for missing user
-    resp = client.post(f'api/notifications/', {"username": "no_user_exists"})
+    resp = client.post(f'api/notifications/',
+                       {"username": "no_user_exists", "notification_type": "password_reset"})
     mock_send.assert_not_called
     assert mock_send.call_args is None
 
@@ -232,14 +233,14 @@ def test_account_password_reset_notification(mock_send, db):
 
     # notification for valid username
     resp = client.post(f'api/notifications/',
-                       json={"username": "DakotaMcclain"})
+                       json={"username": "DakotaMcclain", "notification_type": "password_reset"})
     mock_send.assert_called
     assert mock_send.call_args is not None
     # can't verify Arg contents :(
 
     # notification for email username
     resp = client.post(f'api/notifications/',
-                       json={"email": "rebecca03@thomasrivera.com"})
+                       json={"email": "rebecca03@thomasrivera.com", "notification_type": "password_reset"})
     mock_send.assert_called
     assert mock_send.call_args is not None
 
@@ -256,7 +257,7 @@ def test_account_password_reset_hash_stored(db):
 
     # notification for valid username
     resp = client.post(f'api/notifications/',
-                       json={"username": "DakotaMcclain"})
+                       json={"username": "DakotaMcclain", "notification_type": "password_reset"})
 
     resp = client.get(f'api/account_settings/{uuid}')
     settings = resp.json()
@@ -277,7 +278,7 @@ def test_reset_account_password_with_hash(db):
 
     # notification for valid username
     resp = client.post(f'api/notifications/',
-                       json={"username": "DakotaMcclain"})
+                       json={"username": "DakotaMcclain", "notification_type": "password_reset"})
 
     settings = client.get(f'api/account_settings/{uuid}').json()
     print(settings)

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -338,17 +338,18 @@ def test_verify_account_with_hash(db):
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
     settings = client.get(f'api/account_settings/{uuid}').json()
-    verify_hash = settings['verify_account_hash']
-    cancel_hash = settings['cancel_registration_hash']
+    print(settings)
+    # verify_hash = settings['verify_account_hash']
+    # cancel_hash = settings['cancel_registration_hash']
 
     assert resp.status_code == 204
-    assert verify_hash is not None
-    assert cancel_hash is not None
+    # assert verify_hash is not None
+    # assert cancel_hash is not None
 
-    resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
-    resp_json = resp.json()
+    # resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
+    # resp_json = resp.json()
 
-    assert resp.status_code == 204
-    assert resp_json['verify_account_hash'] is None
-    assert resp_json['cancel_registration_hash'] is not None
-    assert resp_json['is_verified'] is True
+    # assert resp.status_code == 204
+    # assert resp_json['verify_account_hash'] is None
+    # assert resp_json['cancel_registration_hash'] is not None
+    # assert resp_json['is_verified'] is True

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -334,7 +334,7 @@ def test_verify_account_with_hash(db):
     response = client.post(f'api/accounts/', json=account).json()
     uuid = response['uuid']
 
-    # notification for
+    # notification for verifying registration
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
     assert resp.status_code == 204
@@ -342,18 +342,22 @@ def test_verify_account_with_hash(db):
     resp = client.get(f'api/account_settings/{uuid}')
     assert resp.status_code == 200
 
-    # settings = resp.json()
-    # reset_hash = settings['password_reset_hash']
-    # assert reset_hash is None
-    # cancel_hash = settings['cancel_registration_hash']
-    # assert cancel_hash is not None
-    # verify_hash = settings['verify_account_hash']
-    # assert verify_hash is not None
+    settings = resp.json()
+    reset_hash = settings['password_reset_hash']
+    assert reset_hash is None
+    cancel_hash = settings['cancel_registration_hash']
+    assert cancel_hash is not None
+    verify_hash = settings['verify_account_hash']
+    assert verify_hash is not None
 
-    # resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
-    # resp_json = resp.json()
+    resp = client.get(f'api/verify_account_from_hash?verify_hash={verify_hash}')
+    resp_json = resp.json()
 
-    # assert resp.status_code == 204
-    # assert resp_json['verify_account_hash'] is None
-    # assert resp_json['cancel_registration_hash'] is not None
-    # assert resp_json['is_verified'] is True
+    assert resp.status_code == 200
+    assert resp_json['verify_account_hash'] is None
+    assert resp_json['cancel_registration_hash'] is not None
+    assert resp_json['is_verified'] is True
+
+    # Cleanup account
+    resp = client.delete(f'api/accounts/{uuid}')
+    assert resp.status_code < 400

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -337,14 +337,18 @@ def test_verify_account_with_hash(db):
     # notification for
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
-
-    settings = client.get(f'api/account_settings/{uuid}').json()
-    verify_hash = settings['verify_account_hash']
-    cancel_hash = settings['cancel_registration_hash']
-
     assert resp.status_code == 204
-    assert verify_hash is not None
+
+    resp = client.get(f'api/account_settings/{uuid}')
+    assert resp.status_code == 200
+
+    settings = resp.json()
+    reset_hash = settings['password_reset_hash']
+    assert reset_hash is None
+    cancel_hash = settings['cancel_registration_hash']
     assert cancel_hash is not None
+    verify_hash = settings['verify_account_hash']
+    assert verify_hash is not None
 
     resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
     resp_json = resp.json()

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -342,18 +342,18 @@ def test_verify_account_with_hash(db):
     resp = client.get(f'api/account_settings/{uuid}')
     assert resp.status_code == 200
 
-    settings = resp.json()
-    reset_hash = settings['password_reset_hash']
-    assert reset_hash is None
-    cancel_hash = settings['cancel_registration_hash']
-    assert cancel_hash is not None
-    verify_hash = settings['verify_account_hash']
-    assert verify_hash is not None
+    # settings = resp.json()
+    # reset_hash = settings['password_reset_hash']
+    # assert reset_hash is None
+    # cancel_hash = settings['cancel_registration_hash']
+    # assert cancel_hash is not None
+    # verify_hash = settings['verify_account_hash']
+    # assert verify_hash is not None
 
-    resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
-    resp_json = resp.json()
+    # resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
+    # resp_json = resp.json()
 
-    assert resp.status_code == 204
-    assert resp_json['verify_account_hash'] is None
-    assert resp_json['cancel_registration_hash'] is not None
-    assert resp_json['is_verified'] is True
+    # assert resp.status_code == 204
+    # assert resp_json['verify_account_hash'] is None
+    # assert resp_json['cancel_registration_hash'] is not None
+    # assert resp_json['is_verified'] is True

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -337,19 +337,19 @@ def test_verify_account_with_hash(db):
     # notification for
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
+
     settings = client.get(f'api/account_settings/{uuid}').json()
-    print(settings)
-    # verify_hash = settings['verify_account_hash']
-    # cancel_hash = settings['cancel_registration_hash']
+    verify_hash = settings['verify_account_hash']
+    cancel_hash = settings['cancel_registration_hash']
 
     assert resp.status_code == 204
-    # assert verify_hash is not None
-    # assert cancel_hash is not None
+    assert verify_hash is not None
+    assert cancel_hash is not None
 
-    # resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
-    # resp_json = resp.json()
+    resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
+    resp_json = resp.json()
 
-    # assert resp.status_code == 204
-    # assert resp_json['verify_account_hash'] is None
-    # assert resp_json['cancel_registration_hash'] is not None
-    # assert resp_json['is_verified'] is True
+    assert resp.status_code == 204
+    assert resp_json['verify_account_hash'] is None
+    assert resp_json['cancel_registration_hash'] is not None
+    assert resp_json['is_verified'] is True

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -313,3 +313,42 @@ def test_reset_account_password_with_hash(db):
 
     resp = client.delete(f'api/accounts/{uuid}')
     assert resp.status_code < 400
+
+
+def test_verify_account_with_hash(db):
+    new_account = {'email': 'rebecca03@thomasrivera.com',
+                   'username': 'DakotaMcclain',
+                   'first_name': 'Jeff',
+                   'last_name': 'Long',
+                   'password': '^7^Cg&kt*X',
+                   'oauth': 'W^9Oa(Qy+L',
+                   'profile_pic': 'http://www.davis-burke.com/',
+                   'city': 'Lake Robertburgh',
+                   'state': 'Virginia',
+                   'zip_code': '20101',
+                   'roles': ['Sales professional,IT',
+                             'Commissioning editor'],
+                   'is_verified': False}
+    account = new_account.copy()
+    account['oauth'] = None
+    response = client.post(f'api/accounts/', json=account).json()
+    uuid = response['uuid']
+
+    # notification for
+    resp = client.post(f'api/notifications/',
+                       json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
+    settings = client.get(f'api/account_settings/{uuid}').json()
+    verify_hash = settings['verify_account_hash']
+    cancel_hash = settings['cancel_registration_hash']
+
+    assert resp.status_code == 204
+    assert verify_hash is not None
+    assert cancel_hash is not None
+
+    resp = client.get(f'/verify_account_from_hash?verify_hash={verify_hash}')
+    resp_json = resp.json()
+
+    assert resp.status_code == 204
+    assert resp_json['verify_account_hash'] is None
+    assert resp_json['cancel_registration_hash'] is not None
+    assert resp_json['is_verified'] is True

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -7315,9 +7315,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001151",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001151.tgz",
-      "integrity": "sha512-Zh3sHqskX6mHNrqUerh+fkf0N72cMxrmflzje/JyVImfpknscMnkeJrlFGJcqTmaa0iszdYptGpWMJCRQDkBVw=="
+      "version": "1.0.30001207",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001207.tgz",
+      "integrity": "sha512-UPQZdmAsyp2qfCTiMU/zqGSWOYaY9F9LL61V8f+8MrubsaDGpaHD9HRV/EWZGULZn0Hxu48SKzI5DgFwTvHuYw=="
     },
     "capture-exit": {
       "version": "2.0.0",

--- a/client/src/components/CancelRegistration.js
+++ b/client/src/components/CancelRegistration.js
@@ -1,13 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
 
 import LoadingSpinner from './LoadingSpinner';
-import { getAccountAndSettingsFromHash } from 'store/user-slice/verify-account';
+import { cancelRegistrationFromhash } from 'store/user-slice/verify-account';
 import { startLogout } from 'store/user-slice';
 
-function VerifyAccount(props) {
+function CancelRegistration(props) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const { user, cookies, startLogout } = props;
@@ -17,7 +16,7 @@ function VerifyAccount(props) {
     const params = new URLSearchParams(window.location.search);
     const hash = params.get('hash');
 
-    getAccountAndSettingsFromHash(hash)
+    cancelRegistrationFromhash(hash)
       .catch((error) => setError(error))
       .finally(() => setLoading(false));
   }, []);
@@ -32,17 +31,17 @@ function VerifyAccount(props) {
     <LoadingSpinner />
   ) : error ? (
     <div className="mt-5 mb-5 text-center">
-      <h2 className="mt-3 mb-3">
-        Oops, it looks like this account verification link is invalid!
+      <h2 className="mt-4 mb-4">
+        Oops, it looks like this registration cancellation link is invalid!
       </h2>
     </div>
   ) : (
     <>
       <div className="mt-5 mb-5 text-center">
-        <h2 className="mt-3 mb-3">Account Registered</h2>
+        <h2 className="mt-4 mb-4">Cancel Registration</h2>
         <p className="mt-3 mb-3">
-          Your account has been verified. You can now{' '}
-          <Link to="/login">log in here.</Link>
+          Your registration has been cancelled. We apologize for any
+          inconvenience.
         </p>
       </div>
     </>
@@ -60,5 +59,5 @@ const mapDispatchToProps = {
 };
 
 export default withCookies(
-  connect(mapStateToProps, mapDispatchToProps)(VerifyAccount)
+  connect(mapStateToProps, mapDispatchToProps)(CancelRegistration)
 );

--- a/client/src/components/CheckRegisterEmail.js
+++ b/client/src/components/CheckRegisterEmail.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+function CheckRegisterEmail() {
+  return (
+    <>
+      <div className="mt-5 mb-5">
+        <h2 className="mt-4 mb-4 text-center">E-mail Verification Required</h2>
+        <p>
+          You're almost done registering for the HF Volunteer Portal! Please
+          check your e-mail account for a verification e-mail. Then click the
+          link to complete registration.
+        </p>
+      </div>
+    </>
+  );
+}
+
+export default CheckRegisterEmail;

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -58,7 +58,7 @@ function Login(props) {
                 handleChange('email', e.target.value);
               }}
               required
-              isInvalid={!!errors.email || !!errors.message}
+              isInvalid={!!errors.email || !!errors.api}
             />
             <Form.Control.Feedback type="invalid">
               {!data.email ? 'Please provide an e-mail address.' : errors.email}
@@ -73,12 +73,12 @@ function Login(props) {
                 handleChange('password', e.target.value);
               }}
               required
-              isInvalid={!!errors.password || !!errors.message}
+              isInvalid={!!errors.password || !!errors.api}
             />
             <Form.Control.Feedback type="invalid">
               {!data.password
                 ? 'Please provide a password.'
-                : errors.password || errors.message}
+                : errors.password || errors.api}
             </Form.Control.Feedback>
             <div className="mt-3 mb-3">
               <p

--- a/client/src/components/PageViewSwitch.js
+++ b/client/src/components/PageViewSwitch.js
@@ -16,6 +16,8 @@ import Login from './Login';
 import LoginCallback from './LoginCallback';
 import Dashboard from './Dashboard';
 import ResetPassword from './ResetPassword';
+import CheckRegisterEmail from './CheckRegisterEmail';
+import VerifyAccount from './VerifyAccount';
 
 // initialize GA
 // REACT_APP_GA_TRACKING_ID can be found in .env
@@ -42,6 +44,12 @@ function PageViewSwitch() {
         <Route path="/roles" exact component={Roles} />
         <Route path="/candidates" exact component={Candidates} />
         <Route path="/register" exact component={Register} />
+        <Route
+          path="/check_register_email"
+          exact
+          component={CheckRegisterEmail}
+        />
+        <Route path="/verify_account" exact component={VerifyAccount} />
         <Route path="/initiatives" exact component={Initiatives} />
         <Route
           path="/initiatives/:ext_id"

--- a/client/src/components/PageViewSwitch.js
+++ b/client/src/components/PageViewSwitch.js
@@ -18,6 +18,7 @@ import Dashboard from './Dashboard';
 import ResetPassword from './ResetPassword';
 import CheckRegisterEmail from './CheckRegisterEmail';
 import VerifyAccount from './VerifyAccount';
+import CancelRegistration from './CancelRegistration';
 
 // initialize GA
 // REACT_APP_GA_TRACKING_ID can be found in .env
@@ -50,6 +51,11 @@ function PageViewSwitch() {
           component={CheckRegisterEmail}
         />
         <Route path="/verify_account" exact component={VerifyAccount} />
+        <Route
+          path="/cancel_registration"
+          exact
+          component={CancelRegistration}
+        />
         <Route path="/initiatives" exact component={Initiatives} />
         <Route
           path="/initiatives/:ext_id"

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -10,7 +10,7 @@ import 'styles/register-login.scss';
 
 function Register(props) {
   document.title = 'HF Volunteer Portal - Create an Account';
-  const [pendingSubmit, setPendingSubmit] = useState(false);
+  const [canRedirect, setCanRedirect] = useState(false);
   const { user, attemptRegister } = props;
   const {
     handleChange,
@@ -25,9 +25,8 @@ function Register(props) {
   const path = window.location.pathname;
 
   const submitWrapper = async (e) => {
-    setPendingSubmit(true);
-    await handleSubmit(e);
-    setPendingSubmit(false);
+    const submitRes = await handleSubmit(e);
+    setCanRedirect(submitRes);
   };
 
   /**
@@ -45,8 +44,10 @@ function Register(props) {
     }
   }
 
-  return user && !pendingSubmit ? (
+  return user ? (
     <Redirect push to="/account/profile" />
+  ) : canRedirect ? (
+    <Redirect push to="/check_register_email" />
   ) : (
     <>
       <h2 className="text-center">

--- a/client/src/components/ResetPassword.js
+++ b/client/src/components/ResetPassword.js
@@ -45,7 +45,7 @@ function ResetPassword(props) {
     <LoadingSpinner />
   ) : submitted ? (
     <div className="mt-5 mb-5 text-center">
-      <h2 className="mt-3 mb-3">Password reset successfully!</h2>
+      <h2 className="mt-4 mb-4">Password reset successfully!</h2>
       <p className="mt-3 mb-3">
         You can now go back to the <Link to="/login">login page</Link> and log
         in with your new password.

--- a/client/src/components/VerifyAccount.js
+++ b/client/src/components/VerifyAccount.js
@@ -1,0 +1,64 @@
+import React, { useEffect, useState } from 'react';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { withCookies } from 'react-cookie';
+
+import LoadingSpinner from './LoadingSpinner';
+import { getAccountAndSettingsFromHash } from 'store/user-slice/verify-account';
+import { startLogout } from 'store/user-slice';
+
+function VerifyAccount(props) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const { user, cookies, startLogout } = props;
+
+  useEffect(() => {
+    setLoading(true);
+    const params = new URLSearchParams(window.location.search);
+    const hash = params.get('hash');
+
+    getAccountAndSettingsFromHash(hash)
+      .catch((error) => setError(error))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      startLogout(cookies);
+    }
+  }, [user]);
+
+  return loading ? (
+    <LoadingSpinner />
+  ) : error ? (
+    <div className="mt-5 mb-5 text-center">
+      <h2 className="mt-3 mb-3">
+        Oops, it looks like this account verification link is invalid!
+      </h2>
+    </div>
+  ) : (
+    <>
+      <div className="mt-5 mb-5 text-center">
+        <h2 className="mt-3 mb-3">Account Registered</h2>
+        <p>
+          Your account has been verified. You can now{' '}
+          <Link to="/login">log in here.</Link>
+        </p>
+      </div>
+    </>
+  );
+}
+
+const mapStateToProps = (state) => {
+  return {
+    user: state.userStore.user,
+  };
+};
+
+const mapDispatchToProps = {
+  startLogout,
+};
+
+export default withCookies(
+  connect(mapStateToProps, mapDispatchToProps)(VerifyAccount)
+);

--- a/client/src/store/user-slice/classes.js
+++ b/client/src/store/user-slice/classes.js
@@ -26,5 +26,7 @@ export class SettingsReqBody {
     this.initiative_map = obj.initiative_map || {};
     this.password_reset_hash = obj.password_reset_hash ?? null;
     this.password_reset_time = obj.password_reset_time ?? null;
+    this.verify_account_hash = obj.verify_account_hash ?? null;
+    this.cancel_registration_hash = obj.cancel_registration_hash ?? null;
   }
 }

--- a/client/src/store/user-slice/classes.js
+++ b/client/src/store/user-slice/classes.js
@@ -11,6 +11,7 @@ export class AccountReqBody {
     this.state = obj.state;
     this.zip_code = obj.zip_code;
     this.roles = obj.roles || [];
+    this.is_verified = obj.is_verified || false;
   }
 }
 

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -103,7 +103,7 @@ export const formHasNoErrors = (errors) => {
   return true;
 };
 
-export const handleApiErrors = (response, errors) => {
+export const handleRegisterErrors = (response, errors) => {
   if (response) {
     if (
       response.data &&

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -242,17 +242,10 @@ export const attemptRegister = (payload) => async (dispatch) => {
       };
       await axios.post(`/api/notifications/`, obj);
     }
-    // const refreshTime = Date.now();
-    // dispatch(setRefreshTime(refreshTime));
-    // const accountData = accountRes.data;
-    // const settings = await getSettings(accountData.uuid);
-    // const user = { ...accountData, ...settings };
-    // dispatch(setUser(user));
-    return;
   } catch (error) {
     handleRegisterErrors(error.response, errors);
+    throw errors;
   }
-  throw errors;
 };
 
 export const attemptChangePassword = (payload) => async (dispatch) => {
@@ -292,7 +285,6 @@ export const attemptChangePassword = (payload) => async (dispatch) => {
 };
 
 export const deleteRole = (payload) => async (dispatch) => {
-  //const response = await axios.delete(`/users/${userSlice.user.ID}/roles/${payload.roleID}`);
   dispatch(completeDelete(payload));
 };
 

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -197,7 +197,6 @@ export const startLogout = (cookies) => async (dispatch) => {
       sameSite: 'none',
       secure: true,
     });
-    dispatch(setRefreshTime(null));
     dispatch(completeLogout());
   } catch (error) {
     console.error(error);
@@ -387,4 +386,33 @@ export const attemptUpdateAccount = (payload) => async (dispatch) => {
   throw errors;
 };
 
+export const getAccountAndSettingsFromHash = (hash, cookies) => async (
+  dispatch
+) => {
+  const errors = {};
+  if (!hash) {
+    errors.message = 'required hash is missing';
+    throw errors;
+  }
+
+  try {
+    cookies.remove('user_id', {
+      path: '/',
+      sameSite: 'none',
+      secure: true,
+    });
+    dispatch(completeLogout());
+    const userRes = await axios.get(
+      `/api/verify_account_from_hash?verify_hash=${hash}`
+    );
+    const refreshTime = Date.now();
+    dispatch(setRefreshTime(refreshTime));
+    dispatch(setUser(userRes.data));
+    return;
+  } catch (error) {
+    console.error(error);
+    errors.api = 'failed to verify account from hash';
+  }
+  throw errors;
+};
 export default userSlice.reducer;

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -10,7 +10,7 @@ import {
   validateUsername,
   sanitizeData,
   formHasNoErrors,
-  handleApiErrors,
+  handleRegisterErrors,
   handlePossibleExpiredToken,
 } from './helpers';
 
@@ -250,7 +250,7 @@ export const attemptRegister = (payload) => async (dispatch) => {
     // dispatch(setUser(user));
     return;
   } catch (error) {
-    handleApiErrors(error.response, errors);
+    handleRegisterErrors(error.response, errors);
   }
   throw errors;
 };

--- a/client/src/store/user-slice/reset-password.js
+++ b/client/src/store/user-slice/reset-password.js
@@ -19,7 +19,9 @@ export const attemptSendResetEmail = async (payload) => {
     errors.usernameOrEmail = 'Invalid username or e-mail';
     throw errors;
   } else {
-    const obj = {};
+    const obj = {
+      notification_type: 'password_reset',
+    };
     if (!hasEmailErr) {
       obj.email = username_or_email;
     } else if (!hasUsernameErr) {

--- a/client/src/store/user-slice/reset-password.js
+++ b/client/src/store/user-slice/reset-password.js
@@ -7,7 +7,6 @@ import {
   validateUsername,
   sanitizeData,
   formHasNoErrors,
-  handleApiErrors,
 } from './helpers';
 
 export const attemptSendResetEmail = async (payload) => {
@@ -40,7 +39,7 @@ export const getSettingsFromHash = async (hash) => {
     return getSettingsRes.data;
   } catch (error) {
     console.error(error);
-    handleApiErrors(error.response, errors);
+    errors.api = 'an error occurred while trying to get settings from hash';
   }
   throw errors;
 };
@@ -65,7 +64,7 @@ export const attemptResetPassword = async (payload) => {
     }
   } catch (error) {
     console.error(error);
-    handleApiErrors(error.response, errors);
+    errors.api = 'an error occurred while trying to reset password';
   }
   throw errors;
 };

--- a/client/src/store/user-slice/verify-account.js
+++ b/client/src/store/user-slice/verify-account.js
@@ -1,0 +1,18 @@
+import axios from 'axios';
+
+export const getAccountAndSettingsFromHash = async (hash) => {
+  const errors = {};
+  if (!hash) {
+    errors.message = 'required hash is missing';
+    throw errors;
+  }
+
+  try {
+    await axios.get(`/api/verify_account_from_hash?verify_hash=${hash}`);
+    return;
+  } catch (error) {
+    console.error(error);
+    errors.detail = error;
+  }
+  throw errors;
+};

--- a/client/src/store/user-slice/verify-account.js
+++ b/client/src/store/user-slice/verify-account.js
@@ -16,3 +16,19 @@ export const getAccountAndSettingsFromHash = async (hash) => {
   }
   throw errors;
 };
+
+export const cancelRegistrationFromhash = async (hash) => {
+  const errors = {};
+  if (!hash) {
+    errors.message = 'required hash is missing';
+    throw errors;
+  }
+
+  try {
+    await axios.delete(`/api/cancel_registration?cancel_hash=${hash}`);
+  } catch (error) {
+    console.error(error);
+    errors.api = 'failed to cancel registration';
+    throw errors;
+  }
+};

--- a/client/src/store/user-slice/verify-account.js
+++ b/client/src/store/user-slice/verify-account.js
@@ -1,22 +1,5 @@
 import axios from 'axios';
 
-export const getAccountAndSettingsFromHash = async (hash) => {
-  const errors = {};
-  if (!hash) {
-    errors.message = 'required hash is missing';
-    throw errors;
-  }
-
-  try {
-    await axios.get(`/api/verify_account_from_hash?verify_hash=${hash}`);
-    return;
-  } catch (error) {
-    console.error(error);
-    errors.detail = error;
-  }
-  throw errors;
-};
-
 export const cancelRegistrationFromhash = async (hash) => {
   const errors = {};
   if (!hash) {

--- a/client/src/store/user-slice/verify-account.js
+++ b/client/src/store/user-slice/verify-account.js
@@ -8,7 +8,9 @@ export const cancelRegistrationFromhash = async (hash) => {
   }
 
   try {
-    await axios.delete(`/api/cancel_registration?cancel_hash=${hash}`);
+    await axios.delete(
+      `/api/cancel_registration_from_hash?cancel_hash=${hash}`
+    );
   } catch (error) {
     console.error(error);
     errors.api = 'failed to cancel registration';

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -131,7 +131,8 @@ CREATE TABLE public.accounts (
     city character varying(32),
     state character varying(32),
     zip_code character varying(32),
-    roles character varying[] NOT NULL
+    roles character varying[] NOT NULL,
+    is_verified boolean NOT NULL
 );
 
 

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -110,7 +110,8 @@ CREATE TABLE public.account_settings (
     initiative_map json NOT NULL,
     password_reset_hash text,
     password_reset_time timestamp without time zone,
-    verify_account_hash text
+    verify_account_hash text,
+    cancel_registration_hash text
 );
 
 

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -109,7 +109,8 @@ CREATE TABLE public.account_settings (
     volunteers_can_see boolean NOT NULL,
     initiative_map json NOT NULL,
     password_reset_hash text,
-    password_reset_time timestamp without time zone
+    password_reset_time timestamp without time zone,
+    verify_account_hash text
 );
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -131,7 +131,8 @@ CREATE TABLE public.accounts (
     city character varying(32),
     state character varying(32),
     zip_code character varying(32),
-    roles character varying[] NOT NULL
+    roles character varying[] NOT NULL,
+    is_verified boolean NOT NULL
 );
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -110,7 +110,8 @@ CREATE TABLE public.account_settings (
     initiative_map json NOT NULL,
     password_reset_hash text,
     password_reset_time timestamp without time zone,
-    verify_account_hash text
+    verify_account_hash text,
+    cancel_registration_hash text
 );
 
 

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -109,7 +109,8 @@ CREATE TABLE public.account_settings (
     volunteers_can_see boolean NOT NULL,
     initiative_map json NOT NULL,
     password_reset_hash text,
-    password_reset_time timestamp without time zone
+    password_reset_time timestamp without time zone,
+    verify_account_hash text
 );
 
 


### PR DESCRIPTION
Requiring users to open an e-mail and confirm registration if they didn't log in with OAuth. This shouldn't affect OAuth users at all.