### PR TITLE
Create emails templating helper functions and spice up emails.

### DIFF
--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -227,7 +227,7 @@ BUTTON_TEMPLATE = f"""<tr><td align="center">
 text-align: center; vertical-align: middle; -webkit-user-select: none; user-select: none; border:
 1px solid transparent; padding: .375rem .75rem; font-size: 1rem; line-height: 1.5;
 border-radius: .25rem; color: #fff; background-color: {button_color}; border-color: {button_color};
-text-decoration: none;">
+text-decoration: none; margin: 1rem auto;">
 {{button_text}}
 </a></td></tr>"""
 

--- a/api/notifications_api.py
+++ b/api/notifications_api.py
@@ -55,19 +55,23 @@ def create_and_send_email(notification_payload: AccountNotificationSchema, exist
                 db.merge(acct_settings)
                 db.commit()
 
-                url_to_click = f'{base_url}/reset_password?hash={password_reset_hash}'
-                email_message += f'<p>We have received a request to reset your password. To reset your password, \
-                        please click the following link: <a href="{url_to_click}">change my password</a></p> \
-                        <p>This link will expire in 15 minutes.</p>'
+                reset_url = f'{base_url}/reset_password?hash={password_reset_hash}'
+                message_body = CreateParagraph(
+                    f"""We have received a request to reset your password. To reset your password,
+                        please click the following""")
+                message_body += CreateButton("Reset Password", reset_url)
+                message_body += CreateParagraph("This link will expire in 15 minutes")
             else:
                 oauth_type = existing_acct.oauth.capitalize()
-                email_message += f'<p>We have received a request to reset your password. \
-                    Your account was created with {oauth_type} OAuth; therefore, \
-                    you cannot set or reset a password. \
-                    Please try signing in with {oauth_type}.</p>'
-            email_message += '<b>If this action was not performed by you, \
-                    someone may be targeting your account. You may want to consider changing your e-mail password. </b>\
-                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
+                message_body = CreateParagraph(
+                    f"""We have received a request to reset your password.
+                    Your account was created with {oauth_type} OAuth; therefore,
+                    you cannot set or reset a password.
+                    Please try signing in with {oauth_type}.""")
+            message_body += CreateParagraph(
+                '<b>If this action was not performed by you, please ignore this message.</b>')
+
+            email_message = BASE_EMAIL_TEMPLATE.format(body_text=message_body)
             nm.send_notification(recipient=existing_acct.email, message=email_message,
                                  channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Password Reset')
         elif notification_payload.notification_type == 'verify_registration':
@@ -87,12 +91,19 @@ def create_and_send_email(notification_payload: AccountNotificationSchema, exist
             verify_url = f'{base_url}/verify_account?hash={verify_account_hash}'
             cancel_url = f'{base_url}/cancel_registration?hash={cancel_registration_hash}'
 
-            email_message = f'<p>Dear {existing_acct.first_name},</p>'
-            email_message += f'<p>We have received a request to create an account. Accounts not created with OAuth require \
-                        e-mail verification. Please click the following link: <a href="{verify_url}">verify my account</a></p>'
-            email_message += f'<b>If this action was not performed by you or performed by accident, \
-                    you may click the following link to undo account creation: <a href="{cancel_url}">undo account registration</a></b>\
-                    <p>Regards, <br/>HF Volunteer Portal Team </p>'
+            message_body = CreateParagraph(f'Hi {existing_acct.first_name},')
+            message_body += CreateParagraph(
+                f"""We have received a request to create an account associated with this email.
+                Please click below to verify your account""")
+            message_body += CreateButton("Verify My Account", verify_url)
+
+            message_body += CreateParagraph(
+                f"""If this action was not performed by you or performed by accident,
+                you may click the following to undo account creation""")
+            message_body += CreateButton("Undo Account Registration", cancel_url)
+
+            email_message = BASE_EMAIL_TEMPLATE.format(body_text=message_body)
+
             nm.send_notification(recipient=existing_acct.email, message=email_message,
                                  channel=NotificationChannel.EMAIL, scheduled_send_date=datetime.now(), subject='HF Volunteer Portal Account Registration')
 
@@ -170,3 +181,58 @@ def minutes_difference(reset_req_time: datetime):
     seconds_diff = abs((curr_time - reset_req_time).seconds)
     minutes_diff = seconds_diff/60
     return minutes_diff
+
+background_color = "#f3f2ef"
+card_background_color = "#ffffff"
+button_color = "#399DAC"
+# For email header image
+base_url = Config['routes']['client']
+if 'localhost' in base_url:
+    # use publicly available image when testing on dev
+    base_url = 'https://staging-volunteer-portal-dv734ug3ua-uc.a.run.app'
+
+#This template contains a card  with the HF rapid response volunteer program logo.
+# paragraphs and buttons should be added as <tr><td> elements. Use the CreateParagraph helper method
+# and concatenate the paragraph strings and insert into the template using the body_text template variable.
+# Try to keep this in sync with the style from the CSS element .shadow-card in the client
+BASE_EMAIL_TEMPLATE = f"""
+<body style="margin: 0; padding: 0; background-color: {background_color}; font-family: Verdana, Geneva, sans-serif;">
+    <table border="0" cellpadding="0" cellspacing="0" width="100%" style="padding:40px 0 0 0;">
+        <tr>
+            <td>
+                <table align="center" border="0" cellpadding="0" cellspacing="0" width="600" bgcolor="#ffffff" style="margin: 2rem auto; padding: 2rem; background: {card_background_color}; box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px; border-radius: 4px;">
+                    <tr>
+                        <td align="center" style="padding: 20px 20px 20px 20px;"> <a href="{base_url}"><img src="{base_url}/static/media/HF-RR-long-logo.8e1b9513.png" alt="Volunteer Portal Logo" title="Volunteer Portal Logo" style="display: block; width:80%; height:auto;" /></a>
+
+                        </td>
+                    </tr>
+                    <tr>
+                        <td style="padding: 30px 20px 30px 20px;">
+                            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="font-size:16px;">
+                            {{body_text}}
+                             <tr><td style="padding: 20px 0 20px 0;">Regards, <br/>HF Volunteer Portal Team</tr></td>'
+                            </table>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+"""
+
+# Try to keep this in sync with the style from the CSS element .btn and .btn-info in the client
+BUTTON_TEMPLATE = f"""<tr><td align="center">
+<a href="{{link}}" style="display: inline-block; font-weight: 400; color: #212529;
+text-align: center; vertical-align: middle; -webkit-user-select: none; user-select: none; border:
+1px solid transparent; padding: .375rem .75rem; font-size: 1rem; line-height: 1.5;
+border-radius: .25rem; color: #fff; background-color: {button_color}; border-color: {button_color};
+text-decoration: none;">
+{{button_text}}
+</a></td></tr>"""
+
+def CreateButton(button_text, link):
+    return BUTTON_TEMPLATE.format(link=link, button_text=button_text)
+
+def CreateParagraph(text):
+    return f'<tr><td style="padding: 20px 0 20px 0;">{text}</td></tr>'

--- a/client/src/components/CancelRegistration.js
+++ b/client/src/components/CancelRegistration.js
@@ -38,7 +38,7 @@ function CancelRegistration(props) {
   ) : (
     <>
       <div className="mt-5 mb-5 text-center">
-        <h2 className="mt-4 mb-4">Cancel Registration</h2>
+        <h2 className="mt-4 mb-4">Registration Cancelled</h2>
         <p className="mt-3 mb-3">
           Your registration has been cancelled. We apologize for any
           inconvenience.


### PR DESCRIPTION
Trying to reference our style sheets from the api to keep the client and the email look and feel in sync was going to be too hard, so I've just manually created some templates within the api based of the client style.

I made some slight changes to the wording of some of the messages.

Styling is more limited on some mail clients than others, so in gmail for example you wont see the drop shadow