### PR TITLE
decoupled identifiers and verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ db-reset-all-from-python:
 	make db-reload-dev
 	make db-save-dev
 	make db-save-test-from-dev
+	make recreate-db
 recreate-db:
 	docker-compose build --no-cache db
 

--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ db-reset-all-from-python:
 	make db-save-dev
 	make db-save-test-from-dev
 	make recreate-db
+	make down
 recreate-db:
 	docker-compose build --no-cache db
 

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -5,3 +5,6 @@ WORKDIR /api
 
 COPY config.yaml requirements.txt gcp_credentials.json* ./
 RUN pip install -r requirements.txt
+
+# set up to run jupyter notebook from dev instance
+RUN pip install jupyterlab

--- a/api/account_api.py
+++ b/api/account_api.py
@@ -1,21 +1,18 @@
-from fastapi import Depends, FastAPI, Form, Request, HTTPException, Header, APIRouter
-from typing import List, Optional, Text, Union, Mapping, Any
-from models import Account, AccountSettings
-from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
-                     AccountNewPasswordSchema, AccountSettingsSchema, AccountNotificationSchema)
-from sqlalchemy.orm import lazyload
-from starlette.middleware.sessions import SessionMiddleware
-from fastapi.encoders import jsonable_encoder
-from initiatives_api import GetAllInitiativeNames
-from settings import Config, Session, get_db
 import logging
-from uuid import uuid4, UUID
-from fastapi_jwt_auth import AuthJWT
-import external_data_sync
-from security import encrypt_password, check_encrypted_password
+from uuid import UUID
 import re
-from datetime import datetime
-from helpers import sanitize_email
+from fastapi import Depends, HTTPException, APIRouter
+from fastapi_jwt_auth import AuthJWT
+from typing import List
+from models import Account, AccountSettings, EmailIdentifier
+from schemas import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
+                     AccountNewPasswordSchema, AccountSettingsSchema)
+from initiatives_api import GetAllInitiativeNames
+from settings import Session, get_db
+from identifiers_helper import IdentifierState, get_or_create_identifier
+
+from security import encrypt_password
+
 router = APIRouter()
 
 # Note: I am leaving these get all routes commented out as they should not be available publicly.
@@ -40,21 +37,24 @@ def create_access_and_refresh_tokens(user_id: str, Authorize: AuthJWT):
         Authorize.set_refresh_cookies(refresh_token)
     except:
         raise HTTPException(
-            status_code=500, detail=f"Error while trying to create and refresh tokens")
+            status_code=500, detail="Error while trying to create and refresh tokens")
 
 
 def check_valid_password(password: str):
     match = re.search(
-        r"^.*(?=.*\d)(?=.*[a-zA-Z])(?=.*\d)(?=.*[`!@#$%^&*()_+\-=[\]{};':\"\\|,.<>/?~]).{6,20}$", password)
+        r"^.*(?=.*\d)(?=.*[a-zA-Z])(?=.*\d)(?=.*[`!@#$%^&*()_+\-=[\]{};':\"\\|,.<>/?~]).{6,20}$",
+        password)
     if match is None:
-        raise HTTPException(status_code=400,
-                            detail=f"Please enter a password between 6 and 20 characters long with at least 1 letter, 1 number, and 1 special character.")
+        raise HTTPException(
+            status_code=400,
+            detail="Please enter a password between 6 and 20 characters long with at least "
+            "1 letter, 1 number, and 1 special character.")
 
 
 def check_matching_user(uuid, Authorize: AuthJWT):
     current_uuid = Authorize.get_jwt_subject()
     if current_uuid != uuid:
-        raise HTTPException(status_code=403, detail=f"unauthorized")
+        raise HTTPException(status_code=403, detail="unauthorized")
 
 
 @router.get("/accounts/{uuid}", response_model=AccountResponseSchema)
@@ -65,17 +65,36 @@ def get_account_by_uuid(uuid, Authorize: AuthJWT = Depends(), db: Session = Depe
 
 
 @router.post("/accounts/", response_model=AccountResponseSchema, status_code=201)
-def create_account(account: AccountCreateRequestSchema, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
-    check_for_existing_username_or_email(account, db)
-    if account.password is not None:
-        check_valid_password(account.password)
-        account.password = encrypt_password(account.password)
-    account = Account(**account.dict())
-    db.add(account)
+def create_account(request: AccountCreateRequestSchema,
+                   Authorize: AuthJWT = Depends(),
+                   db: Session = Depends(get_db)):
+    account = request.account
+    identifier = request.identifier
+    password = request.password
+
+    id_state, identifier = get_or_create_identifier(identifier.type,
+                                                    identifier.identifier,
+                                                    db,
+                                                    EmailIdentifier)
+    check_identifier_on_create(id_state, identifier)
+    check_for_existing_username(account.username, db)
+    new_account = Account(**account.dict())
+    if password is not None:
+        check_valid_password(password)
+        new_account.password = encrypt_password(password)
+
+    db.add(new_account)
     db.commit()
-    create_account_settings(account.uuid, db)
-    create_access_and_refresh_tokens(str(account.uuid), Authorize)
-    return account
+
+    new_account.primary_email_identifier = identifier
+
+    create_account_settings(new_account.uuid, db)
+    create_access_and_refresh_tokens(str(new_account.uuid), Authorize)
+    db.commit()
+    db.flush()
+    db.refresh(new_account)
+
+    return new_account
 
 
 def create_account_settings(uuid, db):
@@ -83,42 +102,46 @@ def create_account_settings(uuid, db):
         uuid=uuid).first()
     if existing_settings is not None:
         raise HTTPException(
-            status_code=400, detail=f"Settings already exist for that account")
+            status_code=400, detail="Settings already exist for that account")
     matching_acct = db.query(Account).filter_by(uuid=uuid).first()
     if matching_acct is None:
         raise HTTPException(
             status_code=400, detail=f"Account with UUID {uuid} does not exist. Cannot create settings")
     initiative_map = {i[0]: False for i in GetAllInitiativeNames(db)}
     new_settings = AccountSettings(
-        **{"uuid": uuid, 'initiative_map': initiative_map})
+        **{"uuid": uuid, 'account_uuid': uuid, 'initiative_map': initiative_map})
     db.add(new_settings)
     db.commit()
     return new_settings
 
 
-def check_for_existing_username_or_email(account: AccountBaseSchema, db: Session):
-    existing_acct = db.query(Account).filter_by(email=account.email).first()
-    errors = {}
-    if existing_acct is not None:
-        errors['email'] = f"An account with the email address {account.email} already exists"
-    existing_acct = db.query(Account).filter_by(
-        username=account.username).first()
-    if existing_acct is not None:
-        errors['username'] = f"An account with the username {account.username} already exists"
-    if len(errors) > 0:
+def check_identifier_on_create(id_state, identifier):
+    if id_state is IdentifierState.HAS_ACCOUNT_NOT_VERIFIED or \
+       id_state is IdentifierState.HAS_ACCOUNT_IS_VERIFIED:
+        message = f"An account with the {identifier.type.value} {identifier.value} already exists"
         raise HTTPException(
-            status_code=400, detail=errors)
+            status_code=400, detail={identifier.type.value: message})
+
+def check_for_existing_username(username: str, db: Session):
+
+    existing_acct = db.query(Account).filter_by(
+        username=username).first()
+    if existing_acct is not None:
+        message = f"An account with the username {username} already exists"
+        raise HTTPException(
+            status_code=400, detail={'username': message})
 
 
 @router.put("/accounts/{uuid}", response_model=AccountResponseSchema)
-def update_account(uuid, account: AccountBaseSchema, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+def update_account(uuid, account: AccountBaseSchema, Authorize: AuthJWT = Depends(),
+                   db: Session = Depends(get_db)):
     Authorize.jwt_required()
     check_matching_user(uuid, Authorize)
     check_for_diff_user_with_same_username(uuid, account, db)
     updated_acct = Account(uuid=uuid, **account.dict())
-    db.merge(updated_acct)
+    account = db.merge(updated_acct)
     db.commit()
-    return updated_acct
+    return account
 
 
 def check_for_diff_user_with_same_username(uuid, account: AccountCreateRequestSchema, db: Session):
@@ -130,17 +153,17 @@ def check_for_diff_user_with_same_username(uuid, account: AccountCreateRequestSc
 
 
 @router.patch("/accounts/{uuid}", response_model=AccountResponseSchema)
-def update_password(uuid, partial_account: AccountNewPasswordSchema, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+def update_password(uuid, partial_account: AccountNewPasswordSchema, Authorize: AuthJWT = Depends(),
+                    db: Session = Depends(get_db)):
     try:
         Authorize.jwt_required()
         check_matching_user(uuid, Authorize)
         account = db.query(Account).filter_by(uuid=uuid).first()
         if partial_account.password is None:
             raise HTTPException(
-                status_code=400, detail=f"Password is missing")
-        else:
-            check_valid_password(partial_account.password)
-            account.password = encrypt_password(partial_account.password)
+                status_code=400, detail="Password is missing")
+        check_valid_password(partial_account.password)
+        account.password = encrypt_password(partial_account.password)
         db.merge(account)
         db.commit()
         db.refresh(account)
@@ -158,7 +181,7 @@ def remove_user(uuid, Authorize: AuthJWT = Depends(), db: Session = Depends(get_
 
 
 def delete_user(uuid: UUID, db: Session):
-    delete_settings(uuid, db)
+    # deleting the account cascades to delete account settings, identifiers, and verification tokens
     delete_account(uuid, db)
 
 
@@ -171,15 +194,6 @@ def delete_account(uuid: UUID, db: Session):
     db.commit()
 
 
-def delete_settings(uuid: UUID, db: Session):
-    settings_to_delete = db.query(AccountSettings).filter_by(uuid=uuid).first()
-    if settings_to_delete is None:
-        raise HTTPException(status_code=400,
-                            detail=f"Settings with UUID {uuid} not found")
-    db.delete(settings_to_delete)
-    db.commit()
-
-
 @router.get("/account_settings/{uuid}", response_model=AccountSettingsSchema)
 def get_settings_by_uuid(uuid, db: Session = Depends(get_db), Authorize: AuthJWT = Depends()):
     Authorize.jwt_required()
@@ -188,7 +202,8 @@ def get_settings_by_uuid(uuid, db: Session = Depends(get_db), Authorize: AuthJWT
 
 
 @router.put("/account_settings/{uuid}", response_model=AccountSettingsSchema)
-def update_settings(uuid, settings: AccountSettingsSchema, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+def update_settings(uuid, settings: AccountSettingsSchema, Authorize: AuthJWT = Depends(),
+                    db: Session = Depends(get_db)):
     Authorize.jwt_required()
     check_matching_user(uuid, Authorize)
     updated_settings = AccountSettings(**settings.dict())

--- a/api/auth.py
+++ b/api/auth.py
@@ -105,11 +105,10 @@ def oauth_login_or_creation(id_type,
                             identifier_class=PersonalIdentifier,
                             city=None,
                             state=None):
-    print("AAAAAAAAAAAAAAAA", identifier_value)
     id_state, identifier = get_or_create_identifier(id_type,
                                                     identifier_value, db,
                                                     identifier_class)
-    print(identifier)
+
     if id_state is IdentifierState.NONE_MATCHING \
        or id_state is IdentifierState.NO_ACCOUNT_IS_VERIFIED \
        or id_state is IdentifierState.NO_ACCOUNT_NOT_VERIFIED:

--- a/api/auth.py
+++ b/api/auth.py
@@ -8,17 +8,19 @@ from authlib.integrations.starlette_client import OAuth, OAuthError
 from fastapi import HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi_jwt_auth import AuthJWT
-from sqlalchemy import and_
 
 from settings import Config, Session, get_db
 from models import Initiative, VolunteerEvent, VolunteerRole, Account
-from models import  PersonalIdentifier, VerificationToken, IdentifierType, NotificationChannel
-from schemas import AccountBasicLoginSchema, AccountPasswordSchema
-from schemas import IdentifierVerificationStart, IdentifierVerificationFinish
+from models import PersonalIdentifier, VerificationToken, IdentifierType, NotificationChannel, EmailIdentifier
+from schemas import AccountBasicLoginSchema, AccountPasswordSchema, AccountWithSettings, AccountResponseSchema
+from schemas import IdentifierVerificationStart, IdentifierVerificationFinishResponse
 from security import encrypt_password, check_encrypted_password
 from sqlalchemy.orm import lazyload
 from account_api import create_access_and_refresh_tokens, create_account_settings
 import notifications_manager
+from identifiers_helper import IdentifierState, get_or_create_identifier
+from notifications_api import create_verification_registration_email
+from helpers import row2dict
 
 router = APIRouter()
 logging.getLogger(__name__).setLevel(logging.INFO)
@@ -82,24 +84,57 @@ async def authorize_google(request: Request, Authorize: AuthJWT = Depends(), db:
     except OAuthError as error:
         return HTMLResponse(f'<h1>{error.error}</h1>')
     user = await oauth.google.parse_id_token(request, token)
-    account = db.query(Account).filter_by(email=user.email).first()
-    if account is None:
-        logging.warning('Creating a new user object for first-time login')
+
+    account = oauth_login_or_creation(id_type=IdentifierType.GOOGLE_ID,
+                                      identifier_value=user.email,
+                                      identifier_class=EmailIdentifier,
+                                      username=user.email.split('@')[0],
+                                      first_name=user.given_name,
+                                      last_name=user.family_name,
+                                      profile_pic=user.picture,
+                                      db=db)
+    return create_token_for_user(Authorize, str(account.uuid))
+
+def oauth_login_or_creation(id_type,
+                            identifier_value,
+                            username,
+                            first_name,
+                            last_name,
+                            profile_pic,
+                            db,
+                            identifier_class=PersonalIdentifier,
+                            city=None,
+                            state=None):
+    print("AAAAAAAAAAAAAAAA", identifier_value)
+    id_state, identifier = get_or_create_identifier(id_type,
+                                                    identifier_value, db,
+                                                    identifier_class)
+    print(identifier)
+    if id_state is IdentifierState.NONE_MATCHING \
+       or id_state is IdentifierState.NO_ACCOUNT_IS_VERIFIED \
+       or id_state is IdentifierState.NO_ACCOUNT_NOT_VERIFIED:
+        logging.info('Creating a new user object for first-time login')
+
+        identifier.verified = True
+        primary_email = identifier if isinstance(identifier, EmailIdentifier) else None
         new_account = Account(
-            email=user.email,
-            username=user.email.split('@')[0],
-            first_name=user.given_name,
-            last_name=user.family_name,
-            oauth='google',
-            profile_pic=user.picture,
-            is_verified=True,
-        )
+            username=username,
+            first_name=first_name,
+            last_name=last_name,
+            profile_pic=profile_pic,
+            primary_email_identifier=primary_email,
+            city=city,
+            state=state)
         db.add(new_account)
         db.commit()
         db.refresh(new_account)
+        identifier.account_uuid = new_account.uuid
+        identifier.verified = True
         create_account_settings(new_account.uuid, db)
         account = new_account
-    return create_token_for_user(Authorize, str(account.uuid))
+    else:
+        account = identifier.account
+    return account
 
 
 @router.post("/create_token")
@@ -121,9 +156,12 @@ def verify_password(payload: AccountPasswordSchema, Authorize: AuthJWT = Depends
             status_code=403, detail=f"Password is incorrect")
 
 
-@router.post("/auth/basic")
+@router.post("/auth/basic", response_model=AccountResponseSchema)
 def authorize_basic(account: AccountBasicLoginSchema, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
-    existing_acct = db.query(Account).filter_by(email=account.email).first()
+    identifier = db.query(PersonalIdentifier).filter_by(value=account.email)\
+                                             .filter_by(type=IdentifierType.EMAIL)\
+                                             .first()
+    existing_acct = identifier.account
     if existing_acct is None:
         raise HTTPException(
             status_code=403, detail=f"E-mail or password is invalid!")
@@ -132,7 +170,7 @@ def authorize_basic(account: AccountBasicLoginSchema, Authorize: AuthJWT = Depen
     if verified_pw is False:
         raise HTTPException(
             status_code=403, detail=f"E-mail or password is invalid!")
-    if existing_acct.is_verified is False:
+    if identifier.verified is False:
         raise HTTPException(
             status_code=403, detail=f"Account has not been verified. Please check your e-mail."
         )
@@ -171,28 +209,20 @@ async def authorize_github(request: Request, Authorize: AuthJWT = Depends(), db:
     resp = await oauth.github.get('user', token=token)
     user = resp.json()
     email_to_use = user['email'] or user['login'] + '@fakegithubemail.com'
-    account = db.query(Account).filter_by(
-        email=email_to_use).first()
 
-    if account is None:
-        new_account = Account(
-            email=email_to_use,
-            username=user['login'],
-            first_name=user['name'],
-            last_name='no last name',
-            oauth='github',
-            profile_pic=user['avatar_url'],
-            city=None if user['location'] is None else user['location'].split(', ')[
-                0],
-            state=None if user['location'] is None else user['location'].split(', ')[
-                1],
-            is_verified=True
-        )
-        db.add(new_account)
-        db.commit()
-        db.refresh(new_account)
-        create_account_settings(new_account.uuid, db)
-        account = new_account
+    account = oauth_login_or_creation(
+        id_type=IdentifierType.GITHUB_ID,
+        identifier_value=email_to_use,
+        identifier_class=EmailIdentifier,
+        username=user['login'],
+        first_name=user['name'],
+        last_name='no last name',
+        profile_pic=user['avatar_url'],
+        city=None if user['location'] is None else user['location'].split(', ')[
+            0],
+        state=None if user['location'] is None else user['location'].split(', ')[
+            1],
+        db=db)
     return create_token_for_user(Authorize, str(account.uuid))
 
 
@@ -221,7 +251,7 @@ def get_verification_url_for_token(token: VerificationToken) -> str:
     # WARNING: never send this directly to the front-end
     # only send this to the user through another medium to be verified by our client/api
 
-    return f'{Config["routes"]["client"]}/verify_identifier?token={token.uuid}&otp={token.otp}'
+    return f'{Config["routes"]["client"]}/verify_account?token={token.uuid}&otp={token.otp}'
 
 
 @router.post("/verify_identifier/start")
@@ -229,25 +259,20 @@ def begin_identifer_verification(request: IdentifierVerificationStart, Authorize
     Authorize.jwt_optional()
     account = get_logged_in_user(Authorize, db)
 
-    existing_identifier = db.query(PersonalIdentifier).filter(and_(PersonalIdentifier.type==request.type, PersonalIdentifier.value==request.identifier)).first()
+    if not account and request.account_uuid:
+        account = db.query(Account).filter_by(uuid=request.account_uuid).first()
 
-    # this would be too much information to expose via a public API; you could use this to determine who our users are
-    if existing_identifier and existing_identifier.verified and existing_identifier.account and not account:
-        raise HTTPException(status_code=403, detail='The provided personal identifier is already verified and associated to an account')
-    if existing_identifier and existing_identifier.verified and existing_identifier.account and account and not existing_identifier.account_uuid == account.uuid:
+    id_state, identifier = get_or_create_identifier(request.type, request.identifier, db)
+
+    has_account = identifier.account_uuid is not None
+    if identifier.verified:
+        raise HTTPException(status_code=403, detail='The provided personal identifier is already verified ')
+
+    if has_account and account and account.uuid != identifier.account_uuid:
         raise HTTPException(status_code=403, detail='The provided personal identifier is already verified and associated with a different account')
-    if existing_identifier and existing_identifier.verified and not existing_identifier.account and account:
-        # currently associating an identifier with an account during this request (so we can enforce that account's ownership on finish)
-        # there's a potential security concern here with accounts "adopting" identifiers they have no ownership of
-        # may in the future need some intermediate state for "account association is pending identifier verification while logged in"
-        pass
-
-    if existing_identifier:
-        identifier = existing_identifier
-    else:
-        new_identifier = PersonalIdentifier(type=request.type, value=request.identifier)
-        db.add(new_identifier)
-        identifier = new_identifier
+    elif account and not identifier.account_uuid:
+        # associate the identifier to the logged in account
+        identifier.account_uuid = account.uuid
 
     identifier.account = account
     token = VerificationToken()
@@ -256,26 +281,31 @@ def begin_identifer_verification(request: IdentifierVerificationStart, Authorize
     db.commit()
 
     if identifier.type is IdentifierType.EMAIL:
-        message = f'Please click <a href={get_verification_url_for_token(token)}>this link</a> to verify your email'
-        notifications_manager.send_notification(identifier.value, message, NotificationChannel.EMAIL, title=f'Please verify your email with {Config["public_facing_org_name"]}')
+        url = get_verification_url_for_token(token)
+        name = identifier.account.first_name if has_account else "friend"
+        message = create_verification_registration_email(name, url, db)
+        notifications_manager.send_notification(
+            identifier.value, message, NotificationChannel.EMAIL,
+            title=f'Please verify your email with {Config["public_facing_org_name"]}')
 
     return {'verification_token_uuid': token.uuid}
 
-@router.post("/verify_identifier/finish")
-def finish_identifier_verification(request: IdentifierVerificationFinish, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+@router.get("/verify_identifier/finish", response_model=IdentifierVerificationFinishResponse)
+def finish_identifier_verification(token: str, otp: str, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
     Authorize.jwt_optional()
-    account = get_logged_in_user(Authorize, db)
-
-    verification_token = db.query(VerificationToken).filter(VerificationToken.uuid==request.verification_token_uuid).first()
+    verification_token = db.query(VerificationToken).filter(VerificationToken.uuid == token).first()
+    identifier = verification_token.personal_identifier
 
     if not verification_token:
         raise HTTPException(status_code=422, detail='No verification token exists for the provided verification_token_uuid')
 
-    if verification_token.personal_identifier and verification_token.personal_identifier.account and account and not verification_token.personal_identifier.account == account.uuid:
-        raise HTTPException(status_code=403, detail='The provided token\'s personal identifier can only be verified by the associated account')
-
     try:
-        verified = verification_token.verify(request.otp, db)
+        verified = verification_token.verify(otp, db)
+        identifier.verified = True
+        verification_token.already_used = True
+
+        db.flush()
+        db.commit()
     except ValueError as e:
         logging.error(e)
         raise HTTPException(status_code=422, detail='The provided token and OTP could not be verified')
@@ -284,4 +314,11 @@ def finish_identifier_verification(request: IdentifierVerificationFinish, Author
         logging.error(f'Attempted verification of token {verification_token.uuid} with incorrect OTP')
         raise HTTPException(status_code=422, detail='The provided token and OTP could not be verified')
     else:
+        account = identifier.account
+        if account is not None:
+            create_access_and_refresh_tokens(
+                str(account.uuid), Authorize)
+            db.flush()
+            db.commit()
+            return {'account': account}
         return {'msg': 'The provided token\'s personal identifier has been verified'}

--- a/api/auth.py
+++ b/api/auth.py
@@ -5,18 +5,23 @@ import logging
 from fastapi import APIRouter, Request, Depends, FastAPI, HTTPException
 import starlette.config
 from authlib.integrations.starlette_client import OAuth, OAuthError
+from fastapi import HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi_jwt_auth import AuthJWT
+from sqlalchemy import and_
 
 from settings import Config, Session, get_db
 from models import Initiative, VolunteerEvent, VolunteerRole, Account
+from models import  PersonalIdentifier, VerificationToken, IdentifierType, NotificationChannel
 from schemas import AccountBasicLoginSchema, AccountPasswordSchema
+from schemas import IdentifierVerificationStart, IdentifierVerificationFinish
 from security import encrypt_password, check_encrypted_password
 from sqlalchemy.orm import lazyload
 from account_api import create_access_and_refresh_tokens, create_account_settings
+import notifications_manager
 
 router = APIRouter()
-app = FastAPI()
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 auth_secret = Config['auth']['jwt']['secret']
 
@@ -207,3 +212,76 @@ def create_token_for_user(Authorize: AuthJWT, user_id: str) -> Dict:
     Authorize.set_access_cookies(access_token, response)
     Authorize.set_refresh_cookies(refresh_token, response)
     return response
+
+def get_logged_in_user(Authorize: AuthJWT, db: Session) -> Account:
+    account_uuid = Authorize.get_jwt_subject()
+    return db.query(Account).filter(Account.uuid==account_uuid).first() if account_uuid else None
+
+def get_verification_url_for_token(token: VerificationToken) -> str:
+    # WARNING: never send this directly to the front-end
+    # only send this to the user through another medium to be verified by our client/api
+
+    return f'{Config["routes"]["client"]}/verify_identifier?token={token.uuid}&otp={token.otp}'
+
+
+@router.post("/verify_identifier/start")
+def begin_identifer_verification(request: IdentifierVerificationStart, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+    Authorize.jwt_optional()
+    account = get_logged_in_user(Authorize, db)
+
+    existing_identifier = db.query(PersonalIdentifier).filter(and_(PersonalIdentifier.type==request.type, PersonalIdentifier.value==request.identifier)).first()
+
+    # this would be too much information to expose via a public API; you could use this to determine who our users are
+    if existing_identifier and existing_identifier.verified and existing_identifier.account and not account:
+        raise HTTPException(status_code=403, detail='The provided personal identifier is already verified and associated to an account')
+    if existing_identifier and existing_identifier.verified and existing_identifier.account and account and not existing_identifier.account_uuid == account.uuid:
+        raise HTTPException(status_code=403, detail='The provided personal identifier is already verified and associated with a different account')
+    if existing_identifier and existing_identifier.verified and not existing_identifier.account and account:
+        # currently associating an identifier with an account during this request (so we can enforce that account's ownership on finish)
+        # there's a potential security concern here with accounts "adopting" identifiers they have no ownership of
+        # may in the future need some intermediate state for "account association is pending identifier verification while logged in"
+        pass
+
+    if existing_identifier:
+        identifier = existing_identifier
+    else:
+        new_identifier = PersonalIdentifier(type=request.type, value=request.identifier)
+        db.add(new_identifier)
+        identifier = new_identifier
+
+    identifier.account = account
+    token = VerificationToken()
+    token.personal_identifier = identifier
+    db.add(token)
+    db.commit()
+
+    if identifier.type is IdentifierType.EMAIL:
+        message = f'Please click <a href={get_verification_url_for_token(token)}>this link</a> to verify your email'
+        notifications_manager.send_notification(identifier.value, message, NotificationChannel.EMAIL, title=f'Please verify your email with {Config["public_facing_org_name"]}')
+
+    return {'verification_token_uuid': token.uuid}
+
+@router.post("/verify_identifier/finish")
+def finish_identifier_verification(request: IdentifierVerificationFinish, Authorize: AuthJWT = Depends(), db: Session = Depends(get_db)):
+    Authorize.jwt_optional()
+    account = get_logged_in_user(Authorize, db)
+
+    verification_token = db.query(VerificationToken).filter(VerificationToken.uuid==request.verification_token_uuid).first()
+
+    if not verification_token:
+        raise HTTPException(status_code=422, detail='No verification token exists for the provided verification_token_uuid')
+
+    if verification_token.personal_identifier and verification_token.personal_identifier.account and account and not verification_token.personal_identifier.account == account.uuid:
+        raise HTTPException(status_code=403, detail='The provided token\'s personal identifier can only be verified by the associated account')
+
+    try:
+        verified = verification_token.verify(request.otp, db)
+    except ValueError as e:
+        logging.error(e)
+        raise HTTPException(status_code=422, detail='The provided token and OTP could not be verified')
+
+    if not verified:
+        logging.error(f'Attempted verification of token {verification_token.uuid} with incorrect OTP')
+        raise HTTPException(status_code=422, detail='The provided token and OTP could not be verified')
+    else:
+        return {'msg': 'The provided token\'s personal identifier has been verified'}

--- a/api/bootstrap.py
+++ b/api/bootstrap.py
@@ -12,6 +12,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from models import Base, Initiative, VolunteerEvent, VolunteerRole, Account, Notification, AccountSettings
+from models import PersonalIdentifier, VerificationToken
 from settings import Connections, Session, ENV
 from tests.fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_volunteer_events_list, generate_fake_initiatives_list
 # from tests.fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_initiatives_list
@@ -63,6 +64,8 @@ Session = sessionmaker(binds={
     Account: engines['database'],
     Notification: engines['database'],
     AccountSettings: engines['database']
+    PersonalIdentifier: engines['database'],
+    VerificationToken: engines['database']
 })
 
 # Create all tables

--- a/api/bootstrap.py
+++ b/api/bootstrap.py
@@ -15,8 +15,7 @@ from models import Base, Initiative, VolunteerEvent, VolunteerRole, Account, Not
 from models import PersonalIdentifier, VerificationToken
 from settings import Connections, Session, ENV
 from tests.fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_volunteer_events_list, generate_fake_initiatives_list
-# from tests.fake_data_utils import generate_fake_volunteer_roles_list, generate_fake_initiatives_list
-
+from sqlalchemy_utils.functions import drop_database, create_database
 
 import logging
 
@@ -28,27 +27,15 @@ logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
 for key in Connections:
     # Connect with `echo` so we can see what's being run
     db_url = Connections[key]['url']
-    engine = create_engine(db_url)
-    conn = engine.connect()
-    conn.execute("commit")
-
-    # conn.execute(f"SELECT 'DROP DATABASE {Connections[key]['database']}' WHERE EXISTS (SELECT FROM pg_database WHERE datname = '{Connections[key]['database']}')")
     try:
-        print(f'\n\nBootstrapping connection {key}')
-        conn.execute(f"DROP DATABASE {Connections[key]['database']}")
-    except:
-        print(f'---- Could not drop database connection {key}')
-    finally:
-        conn.execute("commit")
+        drop_database(db_url)
+    except Exception as e:
+        print(f'---- Could not drop database connection {key} -- {db_url}')
 
     try:
-        print('Creating DB')
-        conn.execute(f"CREATE DATABASE {Connections[key]['database']}")
+        create_database(db_url)
     except:
-        print(f'---- Could not create database connection {key}')
-    finally:
-        conn.execute("commit")
-    conn.close()
+        print(f'---- Could not create database connection {key}  -- {db_url}')
 
 # Connect to all databases
 engines = {}
@@ -63,7 +50,7 @@ Session = sessionmaker(binds={
     VolunteerRole: engines['database'],
     Account: engines['database'],
     Notification: engines['database'],
-    AccountSettings: engines['database']
+    AccountSettings: engines['database'],
     PersonalIdentifier: engines['database'],
     VerificationToken: engines['database']
 })

--- a/api/config.yaml
+++ b/api/config.yaml
@@ -36,49 +36,54 @@ notification_defaults: &notification_defaults
 # Specific configurations for each environment
 
 test:
-  routes:
-    <<: *development_routes_defaults
-  databases:
-    database:
-      generator: db_url_generator
-      adapter: postgresql
-      host: db
-      database: hf_volunteer_portal_test
-      user: admin
-      password: password
-  auth:
-    <<: *auth_defaults
-  notifications:
-    <<: *notification_defaults
+    public_facing_org_name: "[TEST] Humanity Forward's Volunteer Program"
+    routes:
+        <<: *development_routes_defaults
+    databases:
+        database:
+            generator: db_url_generator
+            adapter: postgresql
+            host: db
+            database: hf_volunteer_portal_test
+            user: admin
+            password: password
+    auth:
+        <<: *auth_defaults
+    notifications:
+        <<: *notification_defaults
 development:
-  routes:
-    <<: *development_routes_defaults
-  databases:
-    database:
-      generator: db_url_generator
-      adapter: postgresql
-      host: db
-      database: hf_volunteer_portal_development
-      user: admin
-      password: password
-  auth:
-    # import_auth_credentials_from_secret_store: false
-    <<: *auth_defaults
-  notifications:
-    <<: *notification_defaults
+    public_facing_org_name: "[DEV] Humanity Forward's Volunteer Program"
+    routes:
+        <<: *development_routes_defaults
+    databases:
+        database:
+            generator: db_url_generator
+            adapter: postgresql
+            host: db
+            database: hf_volunteer_portal_development
+            user: admin
+            password: password
+    auth:
+        # import_auth_credentials_from_secret_store: false
+        <<: *auth_defaults
+    notifications:
+        <<: *notification_defaults
 staging:
-  routes:
-    <<: *staging_routes_defaults
-  databases:
-    <<: *production_db_defaults
-  auth:
-    <<: *auth_defaults
-  # TODO update to proper staging config
-  notifications:
-    <<: *notification_defaults
+    public_facing_org_name: "[STAGING] Humanity Forward's Volunteer Program"
+    # TODO verify that this is fine as long as the traffic is all proxies within a single machine.
+    routes:
+        <<: *development_routes_defaults  
+    databases:
+        <<: *production_db_defaults
+    auth:
+        <<: *auth_defaults
+    # TODO update to proper staging config
+    notifications:
+        <<: *notification_defaults  
 production:
-  databases:
-    <<: *production_db_defaults
-  auth:
-    <<: *auth_defaults
-  # TODO add production notification configs
+    public_facing_org_name: "Humanity Forward's Volunteer Program"
+    databases:
+        <<: *production_db_defaults
+    auth:
+        <<: *auth_defaults
+    # TODO add production notification configs

--- a/api/dev_notebooks/README.md
+++ b/api/dev_notebooks/README.md
@@ -1,0 +1,5 @@
+# Jupyter Notebooks For development
+
+The docker-compose dev environments have been setup to run a jupyter notebook kernel alongside the api service so that we can tinker around with a the API environment.
+
+Connect to localhost:8889 after running either the test or dev environment and use the token/password "easy" to login.

--- a/api/dev_notebooks/sqlAlchemy.ipynb
+++ b/api/dev_notebooks/sqlAlchemy.ipynb
@@ -1,0 +1,2101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d0dab924",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from models.base import Base\n",
+    "from sqlalchemy.orm import backref, column_property, relationship, synonym, validates, sessionmaker\n",
+    "from sqlalchemy import Boolean\n",
+    "from sqlalchemy_utils.functions import drop_database, create_database"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0d4021b2",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import sqlalchemy\n",
+    "from sqlalchemy import create_engine, ForeignKey\n",
+    "url = 'postgresql://admin:password@db:5432/test'\n",
+    "drop_database(url)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "0d3e3fd3",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "create_database(url)\n",
+    "engine = create_engine(url, echo=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "841f24d4",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from sqlalchemy import Column, Integer, String"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "65426d38",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# with cascade delete on identifier\n",
+    "#deleting the identifier does nothing with cascae delete on Identifier user relation\n",
+    "#deleting the user does not cascade to its related identifiers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "51517092",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# with cascade delete on user - deleting identifier does nothing\n",
+    "# deleting user deletes the identifiers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "032ef849",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class Identifier(Base):\n",
+    "  __tablename__ = 'ids'\n",
+    "\n",
+    "  id = Column(Integer, primary_key=True)\n",
+    "  value = Column(String)\n",
+    "  verified = Column(Boolean, default=False, nullable=False)\n",
+    "  user_uid = Column(Integer, ForeignKey('users.id'))\n",
+    "  user = relationship('User', foreign_keys=[user_uid], backref='id2')\n",
+    "\n",
+    "  def verify(self):\n",
+    "    self.verified = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "ee85cc9e",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "class User(Base):\n",
+    "  __tablename__ = 'users'\n",
+    "\n",
+    "  id = Column(Integer, primary_key=True)\n",
+    "  name = Column(String)\n",
+    "  identifiers = relationship('Identifier', foreign_keys=[Identifier.user_uid], cascade='save-update, merge, delete')\n",
+    "\n",
+    "  def verify(self):\n",
+    "    for i in self.identifiers:\n",
+    "      i.verified = True"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6f71cfc3",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "Session = sessionmaker(binds={\n",
+    "  Identifier:engine,\n",
+    "  User:engine,})\n",
+    "session = Session()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "77c1008b",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,030 INFO sqlalchemy.engine.base.Engine select version()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,031 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,032 INFO sqlalchemy.engine.base.Engine select current_schema()\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,032 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,034 INFO sqlalchemy.engine.base.Engine SELECT CAST('test plain returns' AS VARCHAR(60)) AS anon_1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,035 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,036 INFO sqlalchemy.engine.base.Engine SELECT CAST('test unicode returns' AS VARCHAR(60)) AS anon_1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,036 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,037 INFO sqlalchemy.engine.base.Engine show standard_conforming_strings\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,038 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,039 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,040 INFO sqlalchemy.engine.base.Engine {'name': 'events'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,041 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,042 INFO sqlalchemy.engine.base.Engine {'name': 'volunteer_openings'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,043 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,043 INFO sqlalchemy.engine.base.Engine {'name': 'initiatives'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,045 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,045 INFO sqlalchemy.engine.base.Engine {'name': 'notifications'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,047 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,047 INFO sqlalchemy.engine.base.Engine {'name': 'personal_identifiers'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,049 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,049 INFO sqlalchemy.engine.base.Engine {'name': 'verification_tokens'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,050 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,051 INFO sqlalchemy.engine.base.Engine {'name': 'account_settings'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,052 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,052 INFO sqlalchemy.engine.base.Engine {'name': 'accounts'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,054 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,054 INFO sqlalchemy.engine.base.Engine {'name': 'ids'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,055 INFO sqlalchemy.engine.base.Engine select relname from pg_class c join pg_namespace n on n.oid=c.relnamespace where pg_catalog.pg_table_is_visible(c.oid) and relname=%(name)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,056 INFO sqlalchemy.engine.base.Engine {'name': 'users'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,058 INFO sqlalchemy.engine.base.Engine \n",
+      "            SELECT EXISTS (\n",
+      "                SELECT * FROM pg_catalog.pg_type t\n",
+      "                WHERE t.typname = %(typname)s\n",
+      "                AND pg_type_is_visible(t.oid)\n",
+      "                )\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,059 INFO sqlalchemy.engine.base.Engine {'typname': 'priority'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,060 INFO sqlalchemy.engine.base.Engine CREATE TYPE priority AS ENUM ('TOP_PRIORITY', 'HIGH', 'MEDIUM', 'LOW', 'COULD_BE_NICE', 'NONE')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,061 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,062 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,066 INFO sqlalchemy.engine.base.Engine \n",
+      "            SELECT EXISTS (\n",
+      "                SELECT * FROM pg_catalog.pg_type t\n",
+      "                WHERE t.typname = %(typname)s\n",
+      "                AND pg_type_is_visible(t.oid)\n",
+      "                )\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,066 INFO sqlalchemy.engine.base.Engine {'typname': 'roletype'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,067 INFO sqlalchemy.engine.base.Engine CREATE TYPE roletype AS ENUM ('REQUIRES_APPLICATION', 'OPEN_TO_ALL')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,068 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,069 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,072 INFO sqlalchemy.engine.base.Engine \n",
+      "            SELECT EXISTS (\n",
+      "                SELECT * FROM pg_catalog.pg_type t\n",
+      "                WHERE t.typname = %(typname)s\n",
+      "                AND pg_type_is_visible(t.oid)\n",
+      "                )\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,072 INFO sqlalchemy.engine.base.Engine {'typname': 'notificationchannel'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,074 INFO sqlalchemy.engine.base.Engine CREATE TYPE notificationchannel AS ENUM ('EMAIL', 'SMS', 'SLACK')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,074 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,075 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,078 INFO sqlalchemy.engine.base.Engine \n",
+      "            SELECT EXISTS (\n",
+      "                SELECT * FROM pg_catalog.pg_type t\n",
+      "                WHERE t.typname = %(typname)s\n",
+      "                AND pg_type_is_visible(t.oid)\n",
+      "                )\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,079 INFO sqlalchemy.engine.base.Engine {'typname': 'notificationstatus'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,080 INFO sqlalchemy.engine.base.Engine CREATE TYPE notificationstatus AS ENUM ('SCHEDULED', 'SENT', 'FAILED')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,080 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,081 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,085 INFO sqlalchemy.engine.base.Engine \n",
+      "            SELECT EXISTS (\n",
+      "                SELECT * FROM pg_catalog.pg_type t\n",
+      "                WHERE t.typname = %(typname)s\n",
+      "                AND pg_type_is_visible(t.oid)\n",
+      "                )\n",
+      "                \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,085 INFO sqlalchemy.engine.base.Engine {'typname': 'identifiertype'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,087 INFO sqlalchemy.engine.base.Engine CREATE TYPE identifiertype AS ENUM ('EMAIL', 'PHONE', 'SLACK_ID', 'GOOGLE_ID')\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,087 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,088 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,093 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE events (\n",
+      "\tid VARCHAR(255) NOT NULL, \n",
+      "\tairtable_last_modified TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tupdated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tis_deleted BOOLEAN NOT NULL, \n",
+      "\tuuid UUID NOT NULL, \n",
+      "\tevent_name VARCHAR(255) NOT NULL, \n",
+      "\tevent_graphics JSON[], \n",
+      "\tsignup_link TEXT NOT NULL, \n",
+      "\tstart TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\t\"end\" TIMESTAMP WITHOUT TIME ZONE, \n",
+      "\tdescription TEXT, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,093 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,105 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,110 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE volunteer_openings (\n",
+      "\tid VARCHAR(255) NOT NULL, \n",
+      "\tairtable_last_modified TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tupdated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tis_deleted BOOLEAN NOT NULL, \n",
+      "\tuuid UUID NOT NULL, \n",
+      "\trole_name VARCHAR(255) NOT NULL, \n",
+      "\thero_image_urls JSON[], \n",
+      "\tapplication_signup_form TEXT, \n",
+      "\tmore_info_link TEXT, \n",
+      "\tpriority priority NOT NULL, \n",
+      "\tteam VARCHAR(255)[], \n",
+      "\tteam_lead_ids VARCHAR(255)[], \n",
+      "\tnum_openings INTEGER, \n",
+      "\tminimum_time_commitment_per_week_hours INTEGER, \n",
+      "\tmaximum_time_commitment_per_week_hours INTEGER, \n",
+      "\tjob_overview TEXT, \n",
+      "\twhat_youll_learn TEXT, \n",
+      "\tresponsibilities_and_duties TEXT, \n",
+      "\tqualifications TEXT, \n",
+      "\trole_type roletype NOT NULL, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,111 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,122 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,126 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE initiatives (\n",
+      "\tid VARCHAR(255) NOT NULL, \n",
+      "\tairtable_last_modified TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tupdated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tis_deleted BOOLEAN NOT NULL, \n",
+      "\tuuid UUID NOT NULL, \n",
+      "\tinitiative_name VARCHAR(255) NOT NULL, \n",
+      "\t\"order\" INTEGER NOT NULL, \n",
+      "\tdetails_link VARCHAR(255), \n",
+      "\thero_image_urls JSON[], \n",
+      "\tdescription TEXT NOT NULL, \n",
+      "\troles VARCHAR[] NOT NULL, \n",
+      "\tevents VARCHAR[] NOT NULL, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,126 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,137 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,141 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE notifications (\n",
+      "\tuuid UUID NOT NULL, \n",
+      "\tchannel notificationchannel NOT NULL, \n",
+      "\trecipient TEXT NOT NULL, \n",
+      "\ttitle TEXT, \n",
+      "\tmessage TEXT NOT NULL, \n",
+      "\tscheduled_send_date TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\tstatus notificationstatus NOT NULL, \n",
+      "\tsend_date TIMESTAMP WITHOUT TIME ZONE, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,141 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,153 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,156 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE personal_identifiers (\n",
+      "\tuuid UUID NOT NULL, \n",
+      "\ttype identifiertype NOT NULL, \n",
+      "\tvalue TEXT NOT NULL, \n",
+      "\taccount_uuid UUID, \n",
+      "\tverified BOOLEAN NOT NULL, \n",
+      "\tslack_workspace_id TEXT, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (type, value), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,157 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,174 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,177 INFO sqlalchemy.engine.base.Engine CREATE INDEX ix_account_uuid ON personal_identifiers USING hash (account_uuid)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,178 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,179 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,183 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE accounts (\n",
+      "\tuuid UUID NOT NULL, \n",
+      "\tusername VARCHAR(255), \n",
+      "\tfirst_name VARCHAR(255), \n",
+      "\tlast_name VARCHAR(255), \n",
+      "\tpassword TEXT, \n",
+      "\toauth VARCHAR(32), \n",
+      "\tprofile_pic TEXT, \n",
+      "\tcity VARCHAR(32), \n",
+      "\tstate VARCHAR(32), \n",
+      "\troles VARCHAR[] NOT NULL, \n",
+      "\tzip_code VARCHAR(32), \n",
+      "\tis_verified BOOLEAN NOT NULL, \n",
+      "\t_primary_email_identifier_uuid UUID, \n",
+      "\t_primary_phone_number_identifier_uuid UUID, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,183 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,194 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,198 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE users (\n",
+      "\tid SERIAL NOT NULL, \n",
+      "\tname VARCHAR, \n",
+      "\tPRIMARY KEY (id)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,198 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,220 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,227 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE verification_tokens (\n",
+      "\tuuid UUID NOT NULL, \n",
+      "\tcreated_at TIMESTAMP WITHOUT TIME ZONE NOT NULL, \n",
+      "\talready_used BOOLEAN NOT NULL, \n",
+      "\tcounter BIGINT NOT NULL, \n",
+      "\tpersonal_identifier_uuid UUID, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid), \n",
+      "\tFOREIGN KEY(personal_identifier_uuid) REFERENCES personal_identifiers (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,227 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,238 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,243 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE account_settings (\n",
+      "\tuuid UUID NOT NULL, \n",
+      "\taccount_uuid UUID, \n",
+      "\tshow_name BOOLEAN NOT NULL, \n",
+      "\tshow_email BOOLEAN NOT NULL, \n",
+      "\tshow_location BOOLEAN NOT NULL, \n",
+      "\torganizers_can_see BOOLEAN NOT NULL, \n",
+      "\tvolunteers_can_see BOOLEAN NOT NULL, \n",
+      "\tinitiative_map JSON NOT NULL, \n",
+      "\tpassword_reset_hash TEXT, \n",
+      "\tpassword_reset_time TIMESTAMP WITHOUT TIME ZONE, \n",
+      "\tPRIMARY KEY (uuid), \n",
+      "\tUNIQUE (uuid), \n",
+      "\tFOREIGN KEY(account_uuid) REFERENCES accounts (uuid)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,244 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,256 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,260 INFO sqlalchemy.engine.base.Engine \n",
+      "CREATE TABLE ids (\n",
+      "\tid SERIAL NOT NULL, \n",
+      "\tvalue VARCHAR, \n",
+      "\tverified BOOLEAN NOT NULL, \n",
+      "\tuser_uid INTEGER, \n",
+      "\tPRIMARY KEY (id), \n",
+      "\tFOREIGN KEY(user_uid) REFERENCES users (id)\n",
+      ")\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,260 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,272 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,276 INFO sqlalchemy.engine.base.Engine ALTER TABLE accounts ADD FOREIGN KEY(_primary_phone_number_identifier_uuid) REFERENCES personal_identifiers (uuid)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,277 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,278 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,281 INFO sqlalchemy.engine.base.Engine ALTER TABLE accounts ADD FOREIGN KEY(_primary_email_identifier_uuid) REFERENCES personal_identifiers (uuid)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,282 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,283 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,286 INFO sqlalchemy.engine.base.Engine ALTER TABLE personal_identifiers ADD FOREIGN KEY(account_uuid) REFERENCES accounts (uuid)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,287 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:44,288 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "Base.metadata.create_all(bind=engine)\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "5547a17b",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "u = User(name=\"tuck\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "9a75a816",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "i = Identifier(value=\"tucker@gmailc.om\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "8351be7d",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "i.user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "55f2d757",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:46,751 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:46,753 INFO sqlalchemy.engine.base.Engine INSERT INTO users (name) VALUES (%(name)s) RETURNING users.id\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:46,754 INFO sqlalchemy.engine.base.Engine {'name': 'tuck'}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:46,757 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.add(u)\n",
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "a94de7f2",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:48,891 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:48,892 INFO sqlalchemy.engine.base.Engine INSERT INTO ids (value, verified, user_uid) VALUES (%(value)s, %(verified)s, %(user_uid)s) RETURNING ids.id\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:48,892 INFO sqlalchemy.engine.base.Engine {'value': 'tucker@gmailc.om', 'verified': False, 'user_uid': None}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:48,894 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.add(i)\n",
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "07337500",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.verified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "1778aa86",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "i.verify()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "d603bf38",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.verified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "f687e542",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:57:32,219 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "9741d29d",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:57:38,672 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.verified AS ids_verified, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      " LIMIT %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:57:38,675 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "session.query(Identifier).first().verified"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "f666df68",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:55,009 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:55,010 INFO sqlalchemy.engine.base.Engine SELECT users.id AS users_id, users.name AS users_name \n",
+      "FROM users \n",
+      "WHERE users.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:58:55,010 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "i.user_uid = u.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "ec2225d5",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "i2 = Identifier(value=\"tucker2@gmail.com\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "0609483c",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.User at 0x7f4aa14edb20>"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "00e0095d",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "i2.user_uid = u.id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "7c0f8831",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session.add(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "bf362371",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session.add(i2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "9c365f3b",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,377 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.verified AS ids_verified \n",
+      "FROM ids \n",
+      "WHERE ids.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,380 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,387 INFO sqlalchemy.engine.base.Engine UPDATE ids SET user_uid=%(user_uid)s WHERE ids.id = %(ids_id)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,389 INFO sqlalchemy.engine.base.Engine {'user_uid': 1, 'ids_id': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,392 INFO sqlalchemy.engine.base.Engine INSERT INTO ids (value, verified, user_uid) VALUES (%(value)s, %(verified)s, %(user_uid)s) RETURNING ids.id\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,393 INFO sqlalchemy.engine.base.Engine {'value': 'tucker2@gmail.com', 'verified': False, 'user_uid': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:00,395 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "a438f4b6",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:04,782 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:04,784 INFO sqlalchemy.engine.base.Engine SELECT users.id AS users_id, users.name AS users_name \n",
+      "FROM users \n",
+      "WHERE users.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:04,784 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:04,786 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.verified AS ids_verified, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE %(param_1)s = ids.user_uid\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-22 17:59:04,786 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<__main__.Identifier at 0x7f4aa1d330a0>,\n",
+       " <__main__.Identifier at 0x7f4a883d1550>]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.identifiers[0].verif"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "43eb3953",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:41,953 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:41,957 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE ids.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:41,960 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:41,965 INFO sqlalchemy.engine.base.Engine SELECT users.id AS users_id, users.name AS users_name \n",
+      "FROM users \n",
+      "WHERE users.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:41,967 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.User at 0x7fc3740e7730>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "090e6241",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,201 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE ids.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,202 INFO sqlalchemy.engine.base.Engine {'param_1': 2}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.User at 0x7fc3740e7730>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i2.user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "5a915f84",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,570 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE %(param_1)s = ids.user_uid\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,571 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<__main__.Identifier at 0x7fc374113d60>,\n",
+       " <__main__.Identifier at 0x7fc3846eeac0>]"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.identifiers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "6c515708",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,984 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE %(param_1)s = ids.user_uid\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:42,985 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[<__main__.Identifier at 0x7fc374113d60>,\n",
+       " <__main__.Identifier at 0x7fc3846eeac0>]"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.id2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "e1a94dd0",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.user_uid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "74b73b1d",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.User at 0x7fc3740e7730>"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "i.user"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "3870a6eb",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:44,922 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.flush()\n",
+    "session.commit()\n",
+    "session.flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "d6b54c06",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 20:18:43,759 INFO sqlalchemy.engine.base.Engine DELETE FROM users\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 20:18:43,760 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "ename": "IntegrityError",
+     "evalue": "(psycopg2.errors.ForeignKeyViolation) update or delete on table \"users\" violates foreign key constraint \"ids_user_uid_fkey\" on table \"ids\"\nDETAIL:  Key (id)=(1) is still referenced from table \"ids\".\n\n[SQL: DELETE FROM users]\n(Background on this error at: http://sqlalche.me/e/13/gkpj)",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mForeignKeyViolation\u001b[0m                       Traceback (most recent call last)",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36m_execute_context\u001b[0;34m(self, dialect, constructor, statement, parameters, *args)\u001b[0m\n\u001b[1;32m   1275\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mevt_handled\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1276\u001b[0;31m                     self.dialect.do_execute(\n\u001b[0m\u001b[1;32m   1277\u001b[0m                         \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/default.py\u001b[0m in \u001b[0;36mdo_execute\u001b[0;34m(self, cursor, statement, parameters, context)\u001b[0m\n\u001b[1;32m    607\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdo_execute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 608\u001b[0;31m         \u001b[0mcursor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    609\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mForeignKeyViolation\u001b[0m: update or delete on table \"users\" violates foreign key constraint \"ids_user_uid_fkey\" on table \"ids\"\nDETAIL:  Key (id)=(1) is still referenced from table \"ids\".\n",
+      "\nThe above exception was the direct cause of the following exception:\n",
+      "\u001b[0;31mIntegrityError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-30-dc78907e9b87>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0msession\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mUser\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdelete\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/query.py\u001b[0m in \u001b[0;36mdelete\u001b[0;34m(self, synchronize_session)\u001b[0m\n\u001b[1;32m   3924\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3925\u001b[0m         \u001b[0mdelete_op\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpersistence\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mBulkDelete\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfactory\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msynchronize_session\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3926\u001b[0;31m         \u001b[0mdelete_op\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexec_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3927\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mdelete_op\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrowcount\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3928\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py\u001b[0m in \u001b[0;36mexec_\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1695\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_pre\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1696\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_pre_synchronize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1697\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_exec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1698\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_post_synchronize\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1699\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_do_post\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py\u001b[0m in \u001b[0;36m_do_exec\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m   1928\u001b[0m         \u001b[0mdelete_stmt\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0msql\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdelete\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprimary_table\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontext\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwhereclause\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1929\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1930\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_execute_stmt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdelete_stmt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1931\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1932\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_do_post\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/persistence.py\u001b[0m in \u001b[0;36m_execute_stmt\u001b[0;34m(self, stmt)\u001b[0m\n\u001b[1;32m   1700\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1701\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_execute_stmt\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstmt\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1702\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mquery\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_execute_crud\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstmt\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmapper\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1703\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrowcount\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrowcount\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1704\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/orm/query.py\u001b[0m in \u001b[0;36m_execute_crud\u001b[0;34m(self, stmt, mapper)\u001b[0m\n\u001b[1;32m   3566\u001b[0m         )\n\u001b[1;32m   3567\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 3568\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mconn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstmt\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_params\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   3569\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   3570\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_get_bind_args\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mquerycontext\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36mexecute\u001b[0;34m(self, object_, *multiparams, **params)\u001b[0m\n\u001b[1;32m   1009\u001b[0m             )\n\u001b[1;32m   1010\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1011\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mmeth\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1012\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1013\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_execute_function\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/sql/elements.py\u001b[0m in \u001b[0;36m_execute_on_connection\u001b[0;34m(self, connection, multiparams, params)\u001b[0m\n\u001b[1;32m    296\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_execute_on_connection\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconnection\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    297\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msupports_execution\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 298\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mconnection\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_execute_clauseelement\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmultiparams\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparams\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    299\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    300\u001b[0m             \u001b[0;32mraise\u001b[0m \u001b[0mexc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mObjectNotExecutableError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36m_execute_clauseelement\u001b[0;34m(self, elem, multiparams, params)\u001b[0m\n\u001b[1;32m   1122\u001b[0m             )\n\u001b[1;32m   1123\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1124\u001b[0;31m         ret = self._execute_context(\n\u001b[0m\u001b[1;32m   1125\u001b[0m             \u001b[0mdialect\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1126\u001b[0m             \u001b[0mdialect\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecution_ctx_cls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_init_compiled\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36m_execute_context\u001b[0;34m(self, dialect, constructor, statement, parameters, *args)\u001b[0m\n\u001b[1;32m   1314\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1315\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mBaseException\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1316\u001b[0;31m             self._handle_dbapi_exception(\n\u001b[0m\u001b[1;32m   1317\u001b[0m                 \u001b[0me\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1318\u001b[0m             )\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36m_handle_dbapi_exception\u001b[0;34m(self, e, statement, parameters, cursor, context)\u001b[0m\n\u001b[1;32m   1508\u001b[0m                 \u001b[0mutil\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraise_\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnewraise\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwith_traceback\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexc_info\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfrom_\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1509\u001b[0m             \u001b[0;32melif\u001b[0m \u001b[0mshould_wrap\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1510\u001b[0;31m                 util.raise_(\n\u001b[0m\u001b[1;32m   1511\u001b[0m                     \u001b[0msqlalchemy_exception\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwith_traceback\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mexc_info\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mfrom_\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1512\u001b[0m                 )\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/util/compat.py\u001b[0m in \u001b[0;36mraise_\u001b[0;34m(***failed resolving arguments***)\u001b[0m\n\u001b[1;32m    180\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    181\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 182\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mexception\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    183\u001b[0m         \u001b[0;32mfinally\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m             \u001b[0;31m# credit to\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/base.py\u001b[0m in \u001b[0;36m_execute_context\u001b[0;34m(self, dialect, constructor, statement, parameters, *args)\u001b[0m\n\u001b[1;32m   1274\u001b[0m                             \u001b[0;32mbreak\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1275\u001b[0m                 \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mevt_handled\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1276\u001b[0;31m                     self.dialect.do_execute(\n\u001b[0m\u001b[1;32m   1277\u001b[0m                         \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1278\u001b[0m                     )\n",
+      "\u001b[0;32m/usr/local/lib/python3.8/site-packages/sqlalchemy/engine/default.py\u001b[0m in \u001b[0;36mdo_execute\u001b[0;34m(self, cursor, statement, parameters, context)\u001b[0m\n\u001b[1;32m    606\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    607\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdo_execute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 608\u001b[0;31m         \u001b[0mcursor\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexecute\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mparameters\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    609\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    610\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mdo_execute_no_params\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcursor\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstatement\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcontext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIntegrityError\u001b[0m: (psycopg2.errors.ForeignKeyViolation) update or delete on table \"users\" violates foreign key constraint \"ids_user_uid_fkey\" on table \"ids\"\nDETAIL:  Key (id)=(1) is still referenced from table \"ids\".\n\n[SQL: DELETE FROM users]\n(Background on this error at: http://sqlalche.me/e/13/gkpj)"
+     ]
+    }
+   ],
+   "source": [
+    "session.query(User).delete()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "9db5e27f",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session.delete(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "2eefd85b",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:50,582 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:50,584 INFO sqlalchemy.engine.base.Engine SELECT users.id AS users_id, users.name AS users_name \n",
+      "FROM users \n",
+      "WHERE users.id = %(param_1)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:50,585 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:50,586 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE %(param_1)s = ids.user_uid\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:50,587 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "session.delete(u)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "1bbee6ed",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,404 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids \n",
+      "WHERE %(param_1)s = ids.user_uid\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,405 INFO sqlalchemy.engine.base.Engine {'param_1': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,407 INFO sqlalchemy.engine.base.Engine UPDATE ids SET user_uid=%(user_uid)s WHERE ids.id = %(ids_id)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,408 INFO sqlalchemy.engine.base.Engine ({'user_uid': None, 'ids_id': 1}, {'user_uid': None, 'ids_id': 2})\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,409 INFO sqlalchemy.engine.base.Engine DELETE FROM ids WHERE ids.id = %(id)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,409 INFO sqlalchemy.engine.base.Engine ({'id': 1}, {'id': 2})\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,410 INFO sqlalchemy.engine.base.Engine DELETE FROM users WHERE users.id = %(id)s\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,410 INFO sqlalchemy.engine.base.Engine {'id': 1}\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:51,411 INFO sqlalchemy.engine.base.Engine COMMIT\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.commit()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "844f7ec4",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:53,461 INFO sqlalchemy.engine.base.Engine BEGIN (implicit)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:53,462 INFO sqlalchemy.engine.base.Engine SELECT ids.id AS ids_id, ids.value AS ids_value, ids.user_uid AS ids_user_uid \n",
+      "FROM ids\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:05:53,463 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = session.query(Identifier).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "26af630e",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "r"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "a32e7001",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:06:01,198 INFO sqlalchemy.engine.base.Engine SELECT users.id AS users_id, users.name AS users_name \n",
+      "FROM users\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 22:06:01,199 INFO sqlalchemy.engine.base.Engine {}\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 33,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "session.query(User).all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "f89319e0",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "session.flush()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "352e6d73",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2021-05-20 20:24:02,052 INFO sqlalchemy.engine.base.Engine ROLLBACK\n"
+     ]
+    }
+   ],
+   "source": [
+    "session.rollback()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46d3cc1f",
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "argv": [
+    "python",
+    "-m",
+    "ipykernel_launcher",
+    "-f",
+    "{connection_file}"
+   ],
+   "display_name": "Python 3",
+   "env": null,
+   "interrupt_mode": "signal",
+   "language": "python",
+   "metadata": null,
+   "name": "python3"
+  },
+  "name": "sqlAlchemy.ipynb"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/api/identifiers_helper.py
+++ b/api/identifiers_helper.py
@@ -29,11 +29,8 @@ def get_identifier(id_type, value, db, id_class=PersonalIdentifier):
 
 def get_or_create_identifier(id_type, value, db, id_class=PersonalIdentifier):
     state, identifier = get_identifier(id_type, value, db)
-    print("Bbbbbbbbb", value)
     if state == IdentifierState.NONE_MATCHING:
-        print("ccccccccccccccccc", value)
         new_identifier = id_class(type=id_type, value=value)
-        print("NEW ID", new_identifier)
         db.add(new_identifier)
         identifier = new_identifier
         db.commit()

--- a/api/identifiers_helper.py
+++ b/api/identifiers_helper.py
@@ -1,0 +1,40 @@
+from enum import Enum
+from sqlalchemy import and_
+
+from models import PersonalIdentifier
+
+class IdentifierState(Enum):
+    NO_ACCOUNT_NOT_VERIFIED = 1
+    NO_ACCOUNT_IS_VERIFIED = 2
+    HAS_ACCOUNT_NOT_VERIFIED = 3
+    HAS_ACCOUNT_IS_VERIFIED = 4
+    NONE_MATCHING = 5
+
+def get_identifier(id_type, value, db, id_class=PersonalIdentifier):
+    existing_identifier = db.query(id_class).filter(
+        and_(id_class.type == id_type,
+             id_class.value == value)).first()
+
+    if not existing_identifier:
+        return IdentifierState.NONE_MATCHING, None
+    if not existing_identifier.account:
+        if not existing_identifier.verified:
+            return IdentifierState.NO_ACCOUNT_NOT_VERIFIED, existing_identifier
+        return IdentifierState.NO_ACCOUNT_IS_VERIFIED, existing_identifier
+
+    else:
+        if not existing_identifier.verified:
+            return IdentifierState.HAS_ACCOUNT_NOT_VERIFIED, existing_identifier
+        return IdentifierState.HAS_ACCOUNT_IS_VERIFIED, existing_identifier
+
+def get_or_create_identifier(id_type, value, db, id_class=PersonalIdentifier):
+    state, identifier = get_identifier(id_type, value, db)
+    print("Bbbbbbbbb", value)
+    if state == IdentifierState.NONE_MATCHING:
+        print("ccccccccccccccccc", value)
+        new_identifier = id_class(type=id_type, value=value)
+        print("NEW ID", new_identifier)
+        db.add(new_identifier)
+        identifier = new_identifier
+        db.commit()
+    return state, identifier

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -6,6 +6,7 @@ from models.role_type import RoleType
 from models.volunteer_event import VolunteerEvent
 from models.volunteer_role import VolunteerRole
 from models.account import Account
-from models.notification import Notification
-from models.account_settings import AccountSettings
+from models.notification import Notification, NotificationChannel
+from models.personal_identifier import PersonalIdentifier, IdentifierType, EmailIdentifier, PhoneNumberIdentifier
+from models.verification_token import VerificationToken
 from models.account import Account

--- a/api/models/__init__.py
+++ b/api/models/__init__.py
@@ -1,12 +1,11 @@
 from models.base import Base
 from models.initiative import Initiative, NestedInitiative
-from models.person import Person
 from models.priority import Priority
 from models.role_type import RoleType
 from models.volunteer_event import VolunteerEvent
 from models.volunteer_role import VolunteerRole
-from models.account import Account
 from models.notification import Notification, NotificationChannel
-from models.personal_identifier import PersonalIdentifier, IdentifierType, EmailIdentifier, PhoneNumberIdentifier
+from models.personal_identifier import PersonalIdentifier, IdentifierType, EmailIdentifier, PhoneNumberIdentifier, StandardEmailIdentifier
 from models.verification_token import VerificationToken
 from models.account import Account
+from models.account_settings import AccountSettings

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -58,6 +58,18 @@ class Account(Base):
     _primary_phone_number_identifier = relationship('PhoneNumberIdentifier', foreign_keys=[_primary_phone_number_identifier_uuid], uselist=False, post_update=True)
 
     @hybrid_property
+    def primary_identifier(self):
+        if self._primary_email_identifier:
+            return self._primary_email_identifier
+        assert len(self.personal_identifiers) > 0, (
+            'unexpected account state with no identifiers')
+        return self.personal_identifiers[0]
+
+    @hybrid_property
+    def primary_identifier_type(self):
+        return self.primary_identifier.type.value
+
+    @hybrid_property
     def primary_email_identifier(self):
         return self._primary_email_identifier
 

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -1,7 +1,8 @@
 from models.base import Base
 
-from models.personal_identifier import IdentifierType, EmailIdentifier, PhoneNumberIdentifier
-from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, ForeignKey, UniqueConstraint
+from models.personal_identifier import IdentifierType, EmailIdentifier, PhoneNumberIdentifier, PersonalIdentifier
+from models.account_settings import AccountSettings
+from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, ForeignKey, UniqueConstraint, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
 from sqlalchemy.orm import backref, column_property, relationship, synonym, validates
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -38,20 +39,19 @@ class Account(Base):
 
     uuid = Column(UUID(as_uuid=True), primary_key=True,
                   default=uuid4, unique=True, nullable=False)
-    username = Column('username', String(255), nullable=True)
+    username = Column('username', String(255), nullable=True, unique=True)
     first_name = Column('first_name', String(255), nullable=True)
     last_name = Column('last_name', String(255), nullable=True)
     # passwords are encrypted using passlib with pbkdf2_sha256 hashing (see security.py)
     password = Column('password', Text, nullable=True)
-    oauth = Column('oauth', String(32), nullable=True)
     profile_pic = Column('profile_pic', Text, nullable=True)
     city = Column('city', String(32), nullable=True)
     state = Column('state', String(32), nullable=True)
     roles = Column('roles', ARRAY(String), default=[], nullable=False)
     zip_code = Column('zip_code', String(32), nullable=True)
-    is_verified = Column('is_verified', Boolean, default=False, nullable=False)
-    personal_identifiers = relationship('PersonalIdentifier', primaryjoin='Account.uuid==PersonalIdentifier.account_uuid', back_populates='account')
-    # TODO check this over -- can we do a email_identifiers list?
+    settings = relationship('AccountSettings', foreign_keys=[AccountSettings.account_uuid], uselist=False, cascade='delete')
+    personal_identifiers = relationship('PersonalIdentifier', back_populates='account', foreign_keys=[PersonalIdentifier.account_uuid], cascade='delete')
+
     _primary_email_identifier_uuid = Column(UUID(as_uuid=True), ForeignKey('personal_identifiers.uuid'))
     _primary_email_identifier = relationship('EmailIdentifier', foreign_keys=[_primary_email_identifier_uuid], uselist=False, post_update=True)
     _primary_phone_number_identifier_uuid = Column(UUID(as_uuid=True), ForeignKey('personal_identifiers.uuid'))
@@ -63,7 +63,9 @@ class Account(Base):
 
     @primary_email_identifier.setter
     def primary_email_identifier(self, email_identifier):
-        assert type(email_identifier) is EmailIdentifier
+        if not email_identifier:
+            return
+        assert isinstance(email_identifier, EmailIdentifier)
         self._primary_email_identifier = email_identifier
         email_identifier.account = self
 
@@ -78,7 +80,7 @@ class Account(Base):
         phone_number_identifier.account = self
 
     @hybrid_property
-    def primary_email(self):
+    def email(self):
         return self._primary_email_identifier.value if self._primary_email_identifier else None
 
     @hybrid_property
@@ -86,5 +88,5 @@ class Account(Base):
         return self._primary_phone_number_identifier.value if self._primary_phone_number_identifier else None
 
     def __repr__(self):
-        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', last_name='%s', primary_email_identifier_uuid='%s', primary_phone_number_identifier_uuid='%s')>" % (
-            self.uuid, self.email, self.username, self.first_name, self.last_name, self._primary_email_identifier_uuid, self._primary_phone_number_identifier_uuid)
+        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', primary_email_identifier_uuid='%s', primary_phone_number_identifier_uuid='%s')>" % (
+            self.uuid, self.email, self.username, self.first_name, self._primary_email_identifier_uuid, self._primary_phone_number_identifier_uuid)

--- a/api/models/account.py
+++ b/api/models/account.py
@@ -1,8 +1,9 @@
 from models.base import Base
 
-from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, UniqueConstraint
+from models.personal_identifier import IdentifierType, EmailIdentifier, PhoneNumberIdentifier
+from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
-from sqlalchemy.orm import backref, column_property, relationship, synonym
+from sqlalchemy.orm import backref, column_property, relationship, synonym, validates
 from sqlalchemy.ext.hybrid import hybrid_property
 from pydantic import validator
 from sqlalchemy.sql import func
@@ -10,14 +11,35 @@ from uuid import uuid4
 
 
 class Account(Base):
+    """
+    Attributes
+    ----------
+    uuid : uuid
+        the account's unique identifier
+    username : str
+        the user-defined public username for this account
+    first_name : str
+        the user's first name
+    last_name : str
+        the user's last name
+    personal_identifiers : list of PersonalIdentifier
+        the list of all personal identifiers linked to this account
+    primary_email_identifier : EmailIdentifier
+        the EmailIdentifier object for the user's preferred email
+    primary_email : str
+        the user's preferred email address
+    primary_phone_number_identifier : PhoneNumberIdentifier
+        the PhoneNumberIdentifier object for the user's preferred phone number
+    primary_phone_number: str
+        the user's preferred phone number
+    """
+
     __tablename__ = 'accounts'
 
     uuid = Column(UUID(as_uuid=True), primary_key=True,
                   default=uuid4, unique=True, nullable=False)
-    email = Column('email', Text, unique=True, nullable=False, index=True)
-    username = Column('username', String(255), unique=True,
-                      nullable=False, index=True)
-    first_name = Column('first_name', String(255), nullable=False)
+    username = Column('username', String(255), nullable=True)
+    first_name = Column('first_name', String(255), nullable=True)
     last_name = Column('last_name', String(255), nullable=True)
     # passwords are encrypted using passlib with pbkdf2_sha256 hashing (see security.py)
     password = Column('password', Text, nullable=True)
@@ -28,7 +50,41 @@ class Account(Base):
     roles = Column('roles', ARRAY(String), default=[], nullable=False)
     zip_code = Column('zip_code', String(32), nullable=True)
     is_verified = Column('is_verified', Boolean, default=False, nullable=False)
+    personal_identifiers = relationship('PersonalIdentifier', primaryjoin='Account.uuid==PersonalIdentifier.account_uuid', back_populates='account')
+    # TODO check this over -- can we do a email_identifiers list?
+    _primary_email_identifier_uuid = Column(UUID(as_uuid=True), ForeignKey('personal_identifiers.uuid'))
+    _primary_email_identifier = relationship('EmailIdentifier', foreign_keys=[_primary_email_identifier_uuid], uselist=False, post_update=True)
+    _primary_phone_number_identifier_uuid = Column(UUID(as_uuid=True), ForeignKey('personal_identifiers.uuid'))
+    _primary_phone_number_identifier = relationship('PhoneNumberIdentifier', foreign_keys=[_primary_phone_number_identifier_uuid], uselist=False, post_update=True)
+
+    @hybrid_property
+    def primary_email_identifier(self):
+        return self._primary_email_identifier
+
+    @primary_email_identifier.setter
+    def primary_email_identifier(self, email_identifier):
+        assert type(email_identifier) is EmailIdentifier
+        self._primary_email_identifier = email_identifier
+        email_identifier.account = self
+
+    @hybrid_property
+    def primary_phone_number_identifier(self):
+        return self._primary_phone_number_identifier
+
+    @primary_phone_number_identifier.setter
+    def primary_phone_number_identifier(self, phone_number_identifier):
+        assert type(phone_number_identifier) is PhoneNumberIdentifier
+        self._primary_phone_number_identifier = phone_number_identifier
+        phone_number_identifier.account = self
+
+    @hybrid_property
+    def primary_email(self):
+        return self._primary_email_identifier.value if self._primary_email_identifier else None
+
+    @hybrid_property
+    def primary_phone_number(self):
+        return self._primary_phone_number_identifier.value if self._primary_phone_number_identifier else None
 
     def __repr__(self):
-        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', last_name='%s', password='%s', oauth='%s', profile_pic='%s', city='%s', state='%s', zip_code='%s', roles='%s', is_verified='%s')>" % (
-            self.uuid, self.email, self.username, self.first_name, self.last_name, self.password, self.oauth, self.profile_pic, self.city, self.state, self.zip_code, self.roles, self.is_verified)
+        return "<Account(uuid='%s', email='%s', username='%s', first_name='%s', last_name='%s', primary_email_identifier_uuid='%s', primary_phone_number_identifier_uuid='%s')>" % (
+            self.uuid, self.email, self.username, self.first_name, self.last_name, self._primary_email_identifier_uuid, self._primary_phone_number_identifier_uuid)

--- a/api/models/account_settings.py
+++ b/api/models/account_settings.py
@@ -1,6 +1,6 @@
 from models.base import Base
 
-from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, DateTime
+from sqlalchemy import func, select, Column, String, Integer, Text, Boolean, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
 from sqlalchemy.orm import backref, column_property, relationship, synonym
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -14,6 +14,7 @@ class AccountSettings(Base):
 
     uuid = Column(UUID(as_uuid=True), primary_key=True,
                   default=uuid4, unique=True, nullable=False)
+    account_uuid = Column(UUID(as_uuid=True), ForeignKey('accounts.uuid'), nullable=True)
     show_name = Column('show_name', Boolean, default=False, nullable=False)
     show_email = Column('show_email', Boolean, default=False, nullable=False)
     show_location = Column('show_location', Boolean,
@@ -27,9 +28,6 @@ class AccountSettings(Base):
     password_reset_hash = Column('password_reset_hash', Text, nullable=True)
     password_reset_time = Column(
         'password_reset_time', DateTime, nullable=True)
-    verify_account_hash = Column('verify_account_hash', Text, nullable=True)
-    cancel_registration_hash = Column(
-        'cancel_registration_hash', Text, nullable=True)
 
     def __repr__(self):
         return "<AccountSettings(uuid='%s', show_name='%s', show_email='%s', show_location='%s', organizers_can_see='%s', volunteers_can_see='%s', initiative_map='%s', password_reset_hash='%s', password_reset_time='%s')>" % (

--- a/api/models/airtable_row.py
+++ b/api/models/airtable_row.py
@@ -2,7 +2,7 @@ from sqlalchemy import Column, String, Text, DateTime, Boolean
 from sqlalchemy.sql import func
 
 class AirtableRow():
-  external_id = Column('id', String(255), nullable=False)
+  external_id = Column('id', String(255), nullable=False, unique=True)
   airtable_last_modified = Column('airtable_last_modified', DateTime, nullable=False)
   updated_at = Column('updated_at', DateTime, onupdate=func.now(), default=func.now(), nullable=False)
   is_deleted = Column('is_deleted', Boolean, nullable=False, default=False)

--- a/api/models/notification.py
+++ b/api/models/notification.py
@@ -23,11 +23,12 @@ class NotificationStatus(enum.Enum):
 class Notification(Base):
     __tablename__ = 'notifications'
 
-    notification_uuid = Column(
-        UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
+    # TODO check this over - need to find all instances of notification_uuid
+    uuid = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
     channel = Column('channel', Enum(NotificationChannel), nullable=False)
     recipient = Column('recipient', Text, nullable=False)
-    subject = Column('subject', Text, nullable=True)
+    # TODO subject nullable or title? need to check this over too where is trip using it/how
+    title = Column('title', Text)
     message = Column('message', Text, nullable=False)
     scheduled_send_date = Column(
         'scheduled_send_date', DateTime, default=func.now(), nullable=False)
@@ -36,5 +37,5 @@ class Notification(Base):
     sent_date = Column('send_date', DateTime)
 
     def __repr__(self):
-        return "<Notification(notification_uuid='%s', channel='%s', status='%s', )>" % (
-            self.notification_uuid, self.channel, self.status)
+        return "<Notification(uuid='%s', channel='%s', status='%s', )>" % (
+                                self.uuid, self.channel, self.status)

--- a/api/models/notification.py
+++ b/api/models/notification.py
@@ -23,11 +23,9 @@ class NotificationStatus(enum.Enum):
 class Notification(Base):
     __tablename__ = 'notifications'
 
-    # TODO check this over - need to find all instances of notification_uuid
     uuid = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
     channel = Column('channel', Enum(NotificationChannel), nullable=False)
     recipient = Column('recipient', Text, nullable=False)
-    # TODO subject nullable or title? need to check this over too where is trip using it/how
     title = Column('title', Text)
     message = Column('message', Text, nullable=False)
     scheduled_send_date = Column(

--- a/api/models/person.py
+++ b/api/models/person.py
@@ -1,4 +1,0 @@
-from pydantic import BaseModel
-
-class Person(BaseModel):
-    name: str

--- a/api/models/personal_identifier.py
+++ b/api/models/personal_identifier.py
@@ -1,0 +1,79 @@
+from datetime import datetime, timezone
+from models.base import Base
+import enum
+from uuid import uuid4
+from sqlalchemy import Column, Text, DateTime, Enum, ForeignKey, Boolean, UniqueConstraint
+from sqlalchemy.orm import relationship, validates
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from uuid import uuid4
+from email_validator import validate_email
+import phonenumbers
+
+class IdentifierType(enum.Enum):
+    EMAIL = 'email'
+    PHONE = 'phone_number'
+    SLACK_ID = 'slack_member_id'
+    GOOGLE_ID = 'google_id'
+
+class PersonalIdentifier(Base):
+    __tablename__ = 'personal_identifiers'
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
+    type = Column(Enum(IdentifierType), nullable=False)
+    value = Column(Text, nullable=False)
+    account_uuid = Column(UUID(as_uuid=True), ForeignKey('accounts.uuid'), nullable=True)
+    account = relationship('Account', foreign_keys=[account_uuid], back_populates='personal_identifiers')
+    verified = Column(Boolean, default=False, nullable=False)
+    verification_token = relationship('VerificationToken', back_populates='personal_identifier', uselist=False)
+
+    # enforcing uniqueness on type + value will make app logic much simpler, we accept the problems if two people share the same email, phone, etc.
+    __table_args__ = tuple(UniqueConstraint('type', 'value'))
+
+    __mapper_args__ = {
+        'polymorphic_on': type
+    }
+
+    @validates('value')
+    def ensure_valid_value(self, _, value):
+        if self.type is IdentifierType.EMAIL:
+            return validate_email(value).email
+        elif self.type is IdentifierType.PHONE:
+            phone_number_obj = phonenumbers.parse(value, None)
+            assert phonenumbers.is_valid_number(phone_number_obj)
+            return phonenumbers.format_number(phone_number_obj, phonenumbers.PhoneNumberFormat.E164)
+    
+    def __repr__(self):
+        return "<PersonalIdentifier(uuid='%s', type='%s', value='%s', verified='%s', account_uuid='%s')>" % (
+                                self.uuid, self.type, self.value, self.verified, self.account_uuid)
+
+class EmailIdentifier(PersonalIdentifier):
+    __mapper_args__ = {
+        'polymorphic_identity':IdentifierType.EMAIL
+    }
+
+    # so apparently this isn't a feature yet: https://github.com/sqlalchemy/sqlalchemy/issues/2943
+    # @validates('value')
+    # def ensure_valid_email(self, _, value):
+    #     raise ValueError
+    #     return validate_email(value).email
+
+class PhoneNumberIdentifier(PersonalIdentifier):
+    __mapper_args__ = {
+        'polymorphic_identity':IdentifierType.PHONE
+    }
+
+    # @validates('value')
+    # def ensure_valid_email(self, _, value):
+    #     phone_number_obj = phonenumbers.parse(value, None)
+    #     assert phonenumbers.is_valid_number(phone_number_obj)
+    #     return phonenumbers.format_number(phone_number_obj, phonenumbers.PhoneNumberFormat.E164)
+
+class SlackIdentifier(PersonalIdentifier):
+    __mapper_args__ = {
+        'polymorphic_identity':IdentifierType.SLACK_ID
+    }
+
+    slack_workspace_id = Column(Text)
+
+    __table_args__ = tuple(UniqueConstraint('type', 'value', 'slack_workspace_id'))

--- a/api/models/verification_token.py
+++ b/api/models/verification_token.py
@@ -1,0 +1,64 @@
+from datetime import datetime, timedelta
+from models.base import Base
+import enum
+from uuid import uuid4
+from pydantic import validate_arguments
+from sqlalchemy import Column, DateTime, ForeignKey, Boolean, UniqueConstraint, BigInteger, Table
+from sqlalchemy.orm import relationship, Session
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import func
+from uuid import uuid4
+import pyotp
+
+# this seed should not be hard-coded and instead use the portal_auth_personal_identifiers_otp_seed secret
+# currently cannot use the Config object in any models due to circular dependency with settings.py
+# ideally the DB initialization is factored out of loading and using config.yaml
+otp_generator = pyotp.HOTP('OSY2VOJPGPGRIYDYW4TZXM5WOCHD7JTP')
+valid_token_time_interval = timedelta(seconds=600)
+
+def generate_otp_counter() -> int:
+    # good enough to avoid majority of collisions (faster than a for loop)
+    return otp_generator.at(int(datetime.now().timestamp()*100000))
+
+class VerificationToken(Base):
+    __tablename__ = 'verification_tokens'
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, default=uuid4, unique=True, nullable=False)
+    created_at = Column(DateTime, default=func.now(), nullable=False)
+    already_used = Column(Boolean, default=False, nullable=False)
+    _counter = Column('counter', BigInteger, default=generate_otp_counter, nullable=False)
+    personal_identifier_uuid = Column(UUID(as_uuid=True), ForeignKey('personal_identifiers.uuid'))
+    personal_identifier = relationship('PersonalIdentifier', foreign_keys=[personal_identifier_uuid], back_populates='verification_token')
+
+    @hybrid_property
+    def otp(self) -> str:
+        assert not self.is_expired
+        return otp_generator.at(self._counter)
+
+    @hybrid_property
+    def is_expired(self) -> bool:
+        if not self.created_at:
+            raise ValueError(f'Verification token has not been created in database')
+        return datetime.now() > self.created_at + valid_token_time_interval
+
+    @validate_arguments(config=dict(arbitrary_types_allowed=True))
+    def verify(self, otp: str, session: Session) -> bool:
+        if self.is_expired:
+            raise ValueError(f'Verification token {self.uuid} has expired')
+        elif self.already_used:
+            raise ValueError(f'Verification token {self.uuid} has been previously successfully verified')
+        elif not self.personal_identifier:
+            raise ValueError(f'Verification token {self.uuid} is no longer verifiable')
+
+        verified = otp_generator.verify(otp, self._counter)
+        if verified:
+            self.already_used = True
+
+            if self.personal_identifier:
+                self.personal_identifier.verified = True
+
+            session.add(self)
+            session.commit()
+
+        return verified

--- a/api/models/verification_token.py
+++ b/api/models/verification_token.py
@@ -58,7 +58,6 @@ class VerificationToken(Base):
             if self.personal_identifier:
                 self.personal_identifier.verified = True
 
-            session.add(self)
             session.commit()
 
         return verified

--- a/api/models/volunteer_event.py
+++ b/api/models/volunteer_event.py
@@ -1,7 +1,7 @@
 from constants import placeholder_image
 from models import Base
 from models.airtable_row import AirtableRow
-from sqlalchemy import Column, String, Text, DateTime
+from sqlalchemy import Column, String, Text, DateTime, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import func
@@ -25,3 +25,5 @@ class VolunteerEvent(AirtableRow, Base):
     def __repr__(self):
         return "VolunteerEvent(uuid='%s', external_id='%s', name='%s')" % (
                                 self.uuid, self.external_id, self.event_name)
+
+    __table_args__ = (Index('ix_event_id', 'id', postgresql_using='hash'),)

--- a/api/models/volunteer_role.py
+++ b/api/models/volunteer_role.py
@@ -1,10 +1,9 @@
 from models.base import Base
 from models.airtable_row import AirtableRow
-from models.person import Person
 from models.priority import Priority
 from models.role_type import RoleType
 from constants import placeholder_image
-from sqlalchemy import Column, Enum, String, Integer, Text
+from sqlalchemy import Column, Enum, String, Integer, Text, Index
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, UUID
 from sqlalchemy.orm import column_property, relationship, synonym
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -38,3 +37,4 @@ class VolunteerRole(AirtableRow, Base):
     def __repr__(self):
         return "VolunteerRole(role_uuid='%s', role_external_id='%s', name='%s')" % (
                                 self.uuid, self.external_id, self.role_name)
+    __table_args__ = (Index('ix_role_id', 'id', postgresql_using='hash'),)

--- a/api/notifications_manager.py
+++ b/api/notifications_manager.py
@@ -48,7 +48,7 @@ def send_notification(recipient: str, message: str, channel: NotificationChannel
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def send_email_notification(notification: Notification):
-    logging.error(f'Attempting to send email notification {notification.uuid}')
+    logging.info(f'Attempting to send email notification {notification.uuid}')
     try:
         assert notification.channel is NotificationChannel.EMAIL
 

--- a/api/notifications_manager.py
+++ b/api/notifications_manager.py
@@ -11,8 +11,7 @@ import phonenumbers
 from slack_sdk import WebClient
 from urllib.request import urlopen
 
-logging.basicConfig()
-logging.getLogger('notifications_manager').setLevel(logging.INFO)
+logging.getLogger(__name__).setLevel(logging.INFO)
 
 email_client = SendGridAPIClient(Config['notifications']['sendgrid_api_key'])
 sms_client = Client(Config['notifications']['twilio_sid'],
@@ -21,17 +20,19 @@ slack_client = WebClient(token=Config['notifications']['slack_bot_auth_token'])
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
-def send_notification(recipient: str, message: str, channel: NotificationChannel, scheduled_send_date: datetime = None, subject=None):
+def send_notification(recipient: str, message: str, channel: NotificationChannel, title: str = None, scheduled_send_date: datetime = None):
+    logging.info(f'Initiating a {channel.value} notification')
     notification = Notification(
-        recipient=recipient,
-        subject=subject,
-        message=message,
-        channel=channel,
-        scheduled_send_date=scheduled_send_date
+        recipient = recipient,
+        title = title,
+        message = message,
+        channel = channel,
+        scheduled_send_date = scheduled_send_date
     )
 
     db = Session()
     db.add(notification)
+    db.flush()
 
     if notification.channel is NotificationChannel.EMAIL:
         send_email_notification(notification)
@@ -47,6 +48,7 @@ def send_notification(recipient: str, message: str, channel: NotificationChannel
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
 def send_email_notification(notification: Notification):
+    logging.error(f'Attempting to send email notification {notification.uuid}')
     try:
         assert notification.channel is NotificationChannel.EMAIL
 
@@ -55,8 +57,8 @@ def send_email_notification(notification: Notification):
         email = Mail(
             from_email=Config['notifications']['email_default_from_address'],
             to_emails=recipient_email_address,
-            subject=notification.subject or 'This is a test Vol Portal Email',
-            html_content=notification.message or '<strong>Test email with message</strong> <p>E-mail is working!</p>'
+            subject=notification.title if notification.title else f'An FYI from {Config["public_facing_org_name"]}',
+            html_content=notification.message
         )
 
         response = email_client.send(email)
@@ -64,12 +66,14 @@ def send_email_notification(notification: Notification):
         if response.status_code < 300:
             notification.status = NotificationStatus.SENT
             notification.sent_date = datetime.utcnow()
+            logging.info(f'Successfully sent email notification {notification.uuid}')
         else:
             notification.status = NotificationStatus.FAILED
+            logging.error(f'Failed to send email notification {notification.uuid}')
 
     except Exception as e:
-        logging.error(e)
         notification.status = NotificationStatus.FAILED
+        logging.error(f'Failed to send email notification {notification.uuid} with error {e}')
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
@@ -92,12 +96,14 @@ def send_sms_notification(notification: Notification):
         if response and not response.error_code:
             notification.status = NotificationStatus.SENT
             notification.sent_date = datetime.utcnow()
+            logging.info(f'Successfully sent sms notification {notification.uuid}')
         else:
             notification.status = NotificationStatus.FAILED
+            logging.error(f'Failed to send sms notification {notification.uuid}')
 
     except Exception as e:
-        logging.error(e)
         notification.status = NotificationStatus.FAILED
+        logging.error(f'Failed to send sms notification {notification.uuid} with error {e}')
 
 
 @validate_arguments(config=dict(arbitrary_types_allowed=True))
@@ -113,7 +119,8 @@ def send_slack_notification(notification: Notification):
         # WebClient automatically raises a SlackApiError if response.ok is False; no need to check
         notification.status = NotificationStatus.SENT
         notification.sent_date = datetime.utcnow()
+        logging.info(f'Successfully sent slack notification {notification.uuid}')
 
     except Exception as e:
-        logging.error(e)
         notification.status = NotificationStatus.FAILED
+        logging.error(f'Failed to send slack notification {notification.uuid} with error {e}')

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -24,3 +24,4 @@ passlib
 twilio
 phonenumbers
 slack-sdk
+pyotp

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,6 +8,7 @@ uvicorn[standard]
 gunicorn
 requests
 sqlalchemy
+sqlalchemy-utils
 pybigquery
 pymysql
 psycopg2-binary

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -2,6 +2,7 @@ from schemas.initiative import InitiativeSchema, NestedInitiativeSchema
 from schemas.volunteer_event import VolunteerEventSchema
 from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
-                             AccountBasicLoginSchema, AccountPasswordSchema, AccountNewPasswordSchema, AccountNotificationSchema)
+                             AccountBasicLoginSchema, AccountPasswordSchema, AccountNewPasswordSchema, AccountNotificationSchema,
+                             AccountWithSettings)
 from schemas.account_settings import AccountSettingsSchema
-from schemas.personal_identifier_verification import IdentifierVerificationStart, IdentifierVerificationFinish
+from schemas.personal_identifier_verification import IdentifierVerificationStart, IdentifierVerificationFinishResponse

--- a/api/schemas/__init__.py
+++ b/api/schemas/__init__.py
@@ -4,3 +4,4 @@ from schemas.volunteer_role import VolunteerRoleSchema
 from schemas.account import (AccountCreateRequestSchema, AccountResponseSchema, AccountBaseSchema,
                              AccountBasicLoginSchema, AccountPasswordSchema, AccountNewPasswordSchema, AccountNotificationSchema)
 from schemas.account_settings import AccountSettingsSchema
+from schemas.personal_identifier_verification import IdentifierVerificationStart, IdentifierVerificationFinish

--- a/api/schemas/account.py
+++ b/api/schemas/account.py
@@ -1,31 +1,35 @@
 from pydantic import BaseModel, EmailStr
 from typing import List, Dict, Text, Optional
 from uuid import UUID
-
+from models.personal_identifier import IdentifierType
+from schemas.account_settings import AccountSettingsSchema
 
 class AccountBaseSchema(BaseModel):
-    email: Optional[EmailStr]
     username: Optional[str]
     first_name: Optional[str]
     last_name: Optional[str]
-    oauth: Optional[str]
     profile_pic: Optional[Text]
     city: Optional[str]
     state: Optional[str]
     zip_code: Optional[str]
     roles: Optional[List]
-    is_verified: Optional[bool]
-
     class Config:
         orm_mode = True
 
+class IdentifierVerificationCreate(BaseModel):
+    identifier: str
+    type: IdentifierType
 
-class AccountCreateRequestSchema(AccountBaseSchema):
+class AccountCreateRequestSchema(BaseModel):
+    account: AccountBaseSchema
+    identifier: IdentifierVerificationCreate
     password: Text
-
+    class Config:
+        orm_mode = True
 
 class AccountResponseSchema(AccountBaseSchema):
     uuid: UUID
+    email: Optional[EmailStr]
 
 
 class AccountBasicLoginSchema(BaseModel):
@@ -46,3 +50,6 @@ class AccountNotificationSchema(BaseModel):
     username: Optional[str]
     email: Optional[str]
     notification_type: str
+
+class AccountWithSettings(AccountResponseSchema):
+    settings: Optional[AccountSettingsSchema]

--- a/api/schemas/account.py
+++ b/api/schemas/account.py
@@ -30,6 +30,7 @@ class AccountCreateRequestSchema(BaseModel):
 class AccountResponseSchema(AccountBaseSchema):
     uuid: UUID
     email: Optional[EmailStr]
+    primary_identifier_type: Optional[str]
 
 
 class AccountBasicLoginSchema(BaseModel):

--- a/api/schemas/account_settings.py
+++ b/api/schemas/account_settings.py
@@ -12,10 +12,6 @@ class AccountSettingsSchema(BaseModel):
     organizers_can_see: bool
     volunteers_can_see: bool
     initiative_map: Dict
-    password_reset_hash: Optional[Text]
-    password_reset_time: Optional[datetime]
-    verify_account_hash: Optional[Text]
-    cancel_registration_hash: Optional[Text]
 
     class Config:
         orm_mode = True

--- a/api/schemas/personal_identifier_verification.py
+++ b/api/schemas/personal_identifier_verification.py
@@ -1,0 +1,13 @@
+from datetime import datetime
+from pydantic import BaseModel
+from typing import Optional
+from uuid import UUID
+from models.personal_identifier import IdentifierType
+
+class IdentifierVerificationStart(BaseModel):
+    identifier: str
+    type: IdentifierType
+
+class IdentifierVerificationFinish(BaseModel):
+    verification_token_uuid: UUID
+    otp: str

--- a/api/schemas/personal_identifier_verification.py
+++ b/api/schemas/personal_identifier_verification.py
@@ -3,11 +3,13 @@ from pydantic import BaseModel
 from typing import Optional
 from uuid import UUID
 from models.personal_identifier import IdentifierType
+from schemas.account import AccountWithSettings
 
 class IdentifierVerificationStart(BaseModel):
     identifier: str
     type: IdentifierType
+    account_uuid: Optional[UUID]
 
-class IdentifierVerificationFinish(BaseModel):
-    verification_token_uuid: UUID
-    otp: str
+class IdentifierVerificationFinishResponse(BaseModel):
+    account: Optional[AccountWithSettings]
+    msg: Optional[str]

--- a/api/schemas/volunteer_event.py
+++ b/api/schemas/volunteer_event.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from models import Person, Priority, RoleType
+from models import Priority, RoleType
 from pydantic import BaseModel
 from typing import Optional
 from uuid import UUID

--- a/api/schemas/volunteer_role.py
+++ b/api/schemas/volunteer_role.py
@@ -1,4 +1,4 @@
-from models import Person, Priority, RoleType
+from models import Priority, RoleType
 from pydantic import BaseModel
 from typing import Optional
 from uuid import UUID

--- a/api/settings.py
+++ b/api/settings.py
@@ -7,7 +7,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 from google.cloud import secretmanager  # type: ignore
-from models import Initiative, VolunteerEvent, VolunteerRole, Account, Notification, AccountSettings
+from models import Initiative, VolunteerEvent, VolunteerRole, Account, Notification, AccountSettings, PersonalIdentifier, VerificationToken
 
 ENV = os.environ.get('ENV') if os.environ.get('ENV') else "development"
 
@@ -102,6 +102,8 @@ Session = sessionmaker(binds={
     Account: engine,
     AccountSettings: engine,
     Notification: engine,
+    PersonalIdentifier: engine,
+    VerificationToken: engine
 })
 
 # Api Dependency

--- a/api/tests/models/test_account.py
+++ b/api/tests/models/test_account.py
@@ -26,17 +26,6 @@ def test_account_create_valid(db):
     db.add(account)
     db.commit()
 
-def test_account_create_duplicate_email(db):
-    account = generate_fake_account()
-    db.add(account)
-    account2 = generate_fake_account()
-    account2.email = account.email
-    db.add(account2)
-
-    with pytest.raises(IntegrityError):
-      db.commit()
-
-
 def test_account_create_duplicate_username(db):
     account = generate_fake_account()
     db.add(account)

--- a/api/tests/models/test_verification_token.py
+++ b/api/tests/models/test_verification_token.py
@@ -1,0 +1,94 @@
+import pytest
+from unittest.mock import patch, PropertyMock
+from models import VerificationToken, PhoneNumberIdentifier
+from settings import Session
+
+@pytest.fixture
+def db():
+    return Session()
+
+
+# Will run each test in the `yield` portion
+@pytest.fixture(autouse=True)
+def setup(db):
+    db = Session()
+    yield # this is where the testing happens
+    db.rollback()
+
+def test_successfully_verify_otp(db):
+    token = VerificationToken()
+    identifier_to_verify = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+    token.personal_identifier = identifier_to_verify
+    db.add(token)
+    db.commit()
+
+    otp = token.otp
+    assert token.verify(otp, db)
+    assert identifier_to_verify.verified
+
+    db.delete(token)
+    db.delete(identifier_to_verify)
+    db.commit()
+
+@patch.object(VerificationToken, 'is_expired', new_callable=PropertyMock)
+def test_expired_otp(mock_is_expired, db):
+    with pytest.raises(ValueError) as e:
+        mock_is_expired.return_value = False
+
+        token = VerificationToken()
+        identifier_to_verify = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+        token.personal_identifier = identifier_to_verify
+        db.add(token)
+        db.commit()
+
+        otp = token.otp
+
+        mock_is_expired.return_value = True
+        token.verify(otp, db)
+    assert 'has expired' in e.value.args[0]
+    assert not identifier_to_verify.verified
+
+    db.delete(token)
+    db.delete(identifier_to_verify)
+    db.commit()
+
+def test_already_used_otp(db):
+    with pytest.raises(ValueError) as e:
+        token = VerificationToken()
+        identifier_to_verify = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+        token.personal_identifier = identifier_to_verify
+        db.add(token)
+        db.commit()
+
+        otp = token.otp
+        token.verify(otp, db)
+        token.verify(otp, db)
+    assert 'has been previously successfully verified' in e.value.args[0]
+    assert identifier_to_verify.verified
+
+    db.delete(token)
+    db.delete(identifier_to_verify)
+    db.commit()
+
+def test_previous_token_unverifiable(db):
+    previous_token = VerificationToken()
+    identifier_to_verify = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+    previous_token.personal_identifier = identifier_to_verify
+    db.add(previous_token)
+    db.commit()
+
+    new_token = VerificationToken()
+    new_token.personal_identifier = identifier_to_verify
+    db.add(new_token)
+    db.commit()
+
+    with pytest.raises(ValueError) as e:
+        otp = previous_token.otp
+        previous_token.verify(otp, db)
+    assert 'is no longer verifiable' in e.value.args[0]
+    assert not identifier_to_verify.verified
+
+    db.delete(previous_token)
+    db.delete(new_token)
+    db.delete(identifier_to_verify)
+    db.commit()

--- a/api/tests/models/test_volunteer_event.py
+++ b/api/tests/models/test_volunteer_event.py
@@ -1,6 +1,6 @@
 import pytest
 from datetime import datetime
-from models import VolunteerEvent, Person
+from models import VolunteerEvent
 from settings import Session
 from tests.fake_data_utils import generate_fake_volunteer_event
 from uuid import UUID

--- a/api/tests/models/test_volunteer_role.py
+++ b/api/tests/models/test_volunteer_role.py
@@ -1,5 +1,5 @@
 import pytest
-from models import VolunteerRole, Person, Priority, RoleType
+from models import VolunteerRole, Priority, RoleType
 from settings import Session
 from typing import List
 from tests.fake_data_utils import generate_fake_volunteer_role

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -7,9 +7,9 @@ from api.api import app
 from settings import Session
 
 from schemas import NestedInitiativeSchema, InitiativeSchema, VolunteerEventSchema, VolunteerRoleSchema
-from models import Account, AccountSettings, NestedInitiative
+from models import Account, AccountSettings, NestedInitiative, PersonalIdentifier, Initiative
 
-from tests.fake_data_utils import generate_fake_initiatives_list
+from tests.fake_data_utils import generate_fake_initiatives_list, run_delete
 from tests.test_api import cleanup_initiative
 from tests.test_notifications import MockResponse
 import notifications_manager as nm
@@ -27,27 +27,35 @@ def setup(db):
     yield  # this is where the testing happens
     db.rollback()
 
+    # running query.delete() does not do cascaded deletes
+    run_delete(Account, db)
+    run_delete(PersonalIdentifier, db)
+    run_delete(AccountSettings, db)
+    run_delete(NestedInitiative, db)
+    run_delete(Initiative, db)
+
 
 client = TestClient(app)
 
-valid_account = {'email': 'rebecca03@thomasrivera.com',
-                 'username': 'DakotaMcclain',
+valid_account = {'username': 'DakotaMcclain',
                  'first_name': 'Jeff',
                  'last_name': 'Long',
-                 'password': '^7^Cg&kt*X',
-                 'oauth': 'W^9Oa(Qy+L',
                  'profile_pic': 'http://www.davis-burke.com/',
                  'city': 'Lake Robertburgh',
                  'state': 'Virginia',
                  'zip_code': '20101',
                  'roles': ['Sales professional,IT',
-                           'Commissioning editor'],
-                 'is_verified': True}
-
+                           'Commissioning editor']}
+valid_email_identifier = {'identifier':'rebecca03@thomasrivera.com',
+                          'type': 'email'}
+valid_password = '^7^Cg&kt*X'
+valid_account_creation_request = {'account': valid_account,
+                                  'identifier': valid_email_identifier,
+                                  'password': valid_password}
 
 def test_create_account(db):
-    response = client.post(f'api/accounts/', json=valid_account)
-    assert response.status_code < 400
+    response = client.post(f'api/accounts/', json=valid_account_creation_request)
+    assert response.status_code < 400, response.json()
 
     response_account = response.json()
     assert 'uuid' in response_account
@@ -56,12 +64,15 @@ def test_create_account(db):
     resp = client.get(f'api/accounts/{uuid}')
     response_account = resp.json()
 
+    identifier = db.query(PersonalIdentifier).filter_by(account_uuid=uuid).first()
+    assert not identifier.verified
+
     del_resp = client.delete(f'api/accounts/{uuid}')
     assert del_resp.status_code < 400
 
     assert 'password' not in response_account
     expected_account = valid_account.copy()
-    del expected_account['password']
+    expected_account['email'] = valid_email_identifier['identifier']
     del response_account['uuid']
 
     assert response_account == expected_account
@@ -73,7 +84,6 @@ def test_create_duplicate_email_account(db):
                'first_name': 'Jeff',
                'last_name': 'Long',
                'password': '^7^Cg&kt*X',
-               'oauth': 'W^9Oa(Qy+L',
                'profile_pic': 'http://www.davis-burke.com/',
                'city': 'Lake Robertburgh',
                'state': 'Virginia',
@@ -85,18 +95,22 @@ def test_create_duplicate_email_account(db):
                 'first_name': 'Jeff2',
                 'last_name': 'Long2',
                 'password': '^7^Cg&kt*X2',
-                'oauth': 'W^9Oa(Qy+L2',
                 'profile_pic': 'http://www.davis-burke.com/2',
                 'city': 'Lake Robertburgh2',
                 'state': 'Virginia2',
                 'zip_code': '20101',
                 'roles': ['Commissioning editor2']}
-    response = client.post('api/accounts/', json=account)
-    assert response.status_code < 400
+    request = {'account': account,
+               'identifier': valid_email_identifier,
+               'password': valid_password}
+
+    response = client.post('api/accounts/', json=request)
+    assert response.status_code < 400, response.json()
     assert 'uuid' in response.json()
     uuid = response.json()['uuid']
 
-    response = client.post('api/accounts/', json=account2)
+    request['account'] = account2
+    response = client.post('api/accounts/', json=request)
     assert response.status_code == 400
 
     del_resp = client.delete(f'api/accounts/{uuid}')
@@ -107,7 +121,7 @@ def test_account_creation_and_deletion(db):
     initiatives = generate_fake_initiatives_list(db)
     db.commit()
 
-    response = client.post(f'api/accounts/', json=valid_account)
+    response = client.post(f'api/accounts/', json=valid_account_creation_request)
     assert response.status_code < 400, response.json()
 
     response_account = response.json()
@@ -116,7 +130,7 @@ def test_account_creation_and_deletion(db):
     resp = client.get(f'api/accounts/{uuid}')
     assert response.status_code < 400
     resp = resp.json()
-    assert resp['email'] == valid_account['email']
+    assert resp['email'] == valid_email_identifier['identifier']
     assert 'password' not in resp
 
     resp = client.get(f'api/account_settings/{uuid}')
@@ -142,7 +156,7 @@ def test_account_creation_and_deletion(db):
 
 
 def test_bad_auth_cookie_fails_account_get(db):
-    response = client.post(f'api/accounts/', json=valid_account)
+    response = client.post(f'api/accounts/', json=valid_account_creation_request)
     assert response.status_code < 400, response.json()
 
     response_account = response.json()
@@ -169,7 +183,7 @@ def test_bad_auth_cookie_fails_account_get(db):
 
 def test_account_update(db):
     account = valid_account.copy()
-    response = client.post(f'api/accounts/', json=account)
+    response = client.post(f'api/accounts/', json=valid_account_creation_request)
     response_account = response.json()
     uuid = response_account['uuid']
 
@@ -188,7 +202,7 @@ def test_account_settings_update(db):
     initiatives = generate_fake_initiatives_list(db)
     db.commit()
 
-    response = client.post(f'api/accounts/', json=valid_account)
+    response = client.post(f'api/accounts/', json=valid_account_creation_request)
     response_account = response.json()
     uuid = response_account['uuid']
 
@@ -223,36 +237,41 @@ def test_account_settings_update(db):
 @patch('notifications_manager.email_client.send')
 def test_account_password_reset_notification(mock_send, db):
     # no notification for missing user
+    mock_send.return_value = MockResponse(False)
     resp = client.post(f'api/notifications/',
                        {"username": "no_user_exists", "notification_type": "password_reset"})
     mock_send.assert_not_called
     assert mock_send.call_args is None
 
-    response = client.post(f'api/accounts/', json=valid_account).json()
+    response = client.post(f'api/accounts/', json=valid_account_creation_request).json()
     uuid = response['uuid']
 
     # notification for valid username
+    mock_send.return_value = MockResponse(True)
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "notification_type": "password_reset"})
     mock_send.assert_called
     assert mock_send.call_args is not None
     # can't verify Arg contents :(
 
-    # notification for email username
+    # notification for email
+    mock_send.return_value = MockResponse(True)
     resp = client.post(f'api/notifications/',
                        json={"email": "rebecca03@thomasrivera.com", "notification_type": "password_reset"})
     mock_send.assert_called
     assert mock_send.call_args is not None
 
-    resp = client.get(f'api/account_settings/{uuid}')
-    assert resp.json()['password_reset_hash'] is None
+    settings = db.query(AccountSettings).filter_by(uuid=uuid).first()
+    assert settings.password_reset_hash is not None
     client.delete(f'api/accounts/{uuid}')
 
 
 def test_account_password_reset_hash_stored(db):
     account = valid_account.copy()
-    account['oauth'] = None
-    response = client.post(f'api/accounts/', json=account).json()
+    request = valid_account_creation_request.copy()
+    request['account'] = account
+
+    response = client.post(f'api/accounts/', json=request).json()
     uuid = response['uuid']
 
     # notification for valid username
@@ -262,8 +281,9 @@ def test_account_password_reset_hash_stored(db):
     resp = client.get(f'api/account_settings/{uuid}')
     settings = resp.json()
 
-    assert settings['password_reset_hash'] is not None
-    assert settings['password_reset_time'] is not None
+    settings = db.query(AccountSettings).filter_by(uuid=uuid).first()
+    assert settings.password_reset_hash is not None
+    assert settings.password_reset_time is not None
     client.delete(f'api/accounts/{uuid}')
 
 
@@ -272,18 +292,21 @@ def test_reset_account_password_with_hash(db):
     # the reset hash link, update password, check old password does not work and new does with
     # the basic auth api.
     account = valid_account.copy()
-    account['oauth'] = None
-    response = client.post(f'api/accounts/', json=account).json()
+    request = valid_account_creation_request.copy()
+    request['account'] = account
+    response = client.post(f'api/accounts/', json=request).json()
     uuid = response['uuid']
+
+    verify_account_with_uuid(db, uuid)
 
     # notification for valid username
     resp = client.post(f'api/notifications/',
                        json={"username": "DakotaMcclain", "notification_type": "password_reset"})
 
     settings = client.get(f'api/account_settings/{uuid}').json()
-    print(settings)
     # Can't get hash from email
-    reset_hash = settings['password_reset_hash']
+    settings = db.query(AccountSettings).filter_by(uuid=uuid).first()
+    reset_hash = settings.password_reset_hash
 
     # get a new client to remove existing cookies
     new_client = TestClient(app)
@@ -309,93 +332,72 @@ def test_reset_account_password_with_hash(db):
     assert resp.status_code > 400
     resp = new_client.post(f'api/auth/basic', json={'email': 'rebecca03@thomasrivera.com',
                                                     'password': 'new_password.123'})
-    assert resp.status_code < 400
+    assert resp.status_code < 400, resp.json()
 
     resp = client.delete(f'api/accounts/{uuid}')
     assert resp.status_code < 400
 
+# Testing helper only
+def verify_account_with_uuid(db, uuid):
+    account_obj = db.query(Account).filter_by(uuid=uuid).first()
+    identifiers = account_obj.personal_identifiers
+    for identifier in identifiers:
+        resp = client.post(f'api/verify_identifier/start',
+                           json={"account_uuid": uuid,
+                                 "identifier": identifier.value,
+                                 "type": identifier.type.value})
+        assert resp.status_code == 200, resp.json()
 
-def test_verify_account_with_hash(db):
-    new_account = {'email': 'rebecca03@thomasrivera.com',
-                   'username': 'DakotaMcclain',
-                   'first_name': 'Jeff',
-                   'last_name': 'Long',
-                   'password': '^7^Cg&kt*X',
-                   'oauth': 'W^9Oa(Qy+L',
-                   'profile_pic': 'http://www.davis-burke.com/',
-                   'city': 'Lake Robertburgh',
-                   'state': 'Virginia',
-                   'zip_code': '20101',
-                   'roles': ['Sales professional,IT',
-                             'Commissioning editor'],
-                   'is_verified': False}
-    account = new_account.copy()
-    account['oauth'] = None
-    response = client.post(f'api/accounts/', json=account).json()
+        token = identifier.verification_token
+
+        resp = client.get(
+            f'api/verify_identifier/finish?token={str(token.uuid)}&otp={token.otp}')
+        assert resp.status_code == 200, resp.json()
+
+def test_verify_account_with_token(db):
+    account = valid_account.copy()
+    request = valid_account_creation_request.copy()
+    request['account'] = account
+
+    response = client.post(f'api/accounts/', json=request).json()
     uuid = response['uuid']
 
     # notification for verifying registration
-    resp = client.post(f'api/notifications/',
-                       json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
-    assert resp.status_code == 204
-
-    resp = client.get(f'api/account_settings/{uuid}')
+    # Verification has been moved from api/notifications to api/verify_identifier/start in the auth package.
+    resp = client.post(f'api/verify_identifier/start',
+                       json={"account_uuid": uuid,
+                             "identifier": "rebecca03@thomasrivera.com",
+                             "type": "email"})
     assert resp.status_code == 200
 
-    settings = resp.json()
-    reset_hash = settings['password_reset_hash']
-    assert reset_hash is None
-    cancel_hash = settings['cancel_registration_hash']
-    assert cancel_hash is not None
-    verify_hash = settings['verify_account_hash']
-    assert verify_hash is not None
+    account_obj = db.query(Account).filter_by(uuid=uuid).first()
+    assert len(account_obj.personal_identifiers) == 1
+    identifier = account_obj.personal_identifiers[0]
+    assert identifier.verified is False
+    assert identifier.verification_token is not None
+
+    # Can't get token from email
+    token = identifier.verification_token
 
     resp = client.get(
-        f'api/verify_account_from_hash?verify_hash={verify_hash}')
-    resp_json = resp.json()
+        f'api/verify_identifier/finish?token={str(token.uuid)}&otp={token.otp}')
 
+    # account w/ settings
     assert resp.status_code == 200
-    assert resp_json['verify_account_hash'] is None
-    assert resp_json['cancel_registration_hash'] is None
-    assert resp_json['is_verified'] is True
+    resp_json = resp.json()['account']
+    assert str(resp_json['uuid']) == uuid
+    assert resp_json['settings'] is not None
+
+    # get updated account
+    # different session used by client and test
+    db.flush()
+    db.commit()
+    account_obj = db.query(Account).filter_by(uuid=uuid).first()
+    identifier = account_obj.personal_identifiers[0]
+    assert identifier.verification_token.already_used ==True
+    assert identifier.verified is True
+
 
     # Cleanup account
     resp = client.delete(f'api/accounts/{uuid}')
     assert resp.status_code < 400
-
-
-def test_cancel_registration_with_hash(db):
-    new_account = {'email': 'rebecca03@thomasrivera.com',
-                   'username': 'DakotaMcclain',
-                   'first_name': 'Jeff',
-                   'last_name': 'Long',
-                   'password': '^7^Cg&kt*X',
-                   'oauth': 'W^9Oa(Qy+L',
-                   'profile_pic': 'http://www.davis-burke.com/',
-                   'city': 'Lake Robertburgh',
-                   'state': 'Virginia',
-                   'zip_code': '20101',
-                   'roles': ['Sales professional,IT',
-                             'Commissioning editor'],
-                   'is_verified': False}
-    account = new_account.copy()
-    account['oauth'] = None
-    response = client.post(f'api/accounts/', json=account).json()
-    uuid = response['uuid']
-
-    # notification for verifying registration
-    resp = client.post(f'api/notifications/',
-                       json={"username": "DakotaMcclain", "email": "rebecca03@thomasrivera.com", "notification_type": "verify_registration"})
-    resp = client.get(f'api/account_settings/{uuid}')
-
-    settings = resp.json()
-    cancel_hash = settings['cancel_registration_hash']
-
-    resp = client.delete(
-        f'api/cancel_registration_from_hash?cancel_hash={cancel_hash}')
-    assert resp.status_code == 204
-
-    resp = client.get(f'api/accounts/{uuid}')
-    assert resp.status_code == 200
-    account = resp.json()
-    assert account is None

--- a/api/tests/test_account_api.py
+++ b/api/tests/test_account_api.py
@@ -44,6 +44,7 @@ valid_account = {'username': 'DakotaMcclain',
                  'city': 'Lake Robertburgh',
                  'state': 'Virginia',
                  'zip_code': '20101',
+                 'primary_identifier_type': 'email',
                  'roles': ['Sales professional,IT',
                            'Commissioning editor']}
 valid_email_identifier = {'identifier':'rebecca03@thomasrivera.com',

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -14,7 +14,7 @@ from models import NestedInitiative, Initiative, VolunteerRole, VolunteerEvent
 
 from tests.fake_data_utils import generate_fake_initiative, generate_fake_volunteer_role
 from tests.fake_data_utils import generate_fake_volunteer_event, generate_fake_volunteer_events_list
-from tests.fake_data_utils import generate_fake_initiatives_list
+from tests.fake_data_utils import generate_fake_initiatives_list, run_delete
 
 from sqlalchemy import exc
 
@@ -31,7 +31,10 @@ def setup(db):
     db = Session()
     yield  # this is where the testing happens
     db.rollback()
-
+    run_delete(NestedInitiative, db)
+    run_delete(Initiative, db)
+    run_delete(VolunteerRole, db)
+    run_delete(VolunteerEvent, db)
 
 client = TestClient(app)
 

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -61,7 +61,7 @@ def test_validate_bad_email(mock_send, db):
 def test_send_email_success(mock_send, db):
     mock_send.return_value = MockResponse(True)
 
-    email_address = 'good.email@exmaple.com'
+    email_address = 'good.email@example.com'
     message = fake.paragraph(nb_sentences=10)
     nm.send_notification(email_address, message, NotificationChannel.EMAIL)
 
@@ -82,7 +82,7 @@ def test_send_email_success(mock_send, db):
 def test_send_email_failure(mock_send, db):
     mock_send.return_value = MockResponse(False)
 
-    email_address = 'asdf@!'
+    email_address = 'good.email@example.com'
     message = fake.paragraph(nb_sentences=10)
     nm.send_notification(email_address, message, NotificationChannel.EMAIL)
 

--- a/api/tests/test_notifications.py
+++ b/api/tests/test_notifications.py
@@ -5,7 +5,7 @@ import notifications_manager as nm
 from models.notification import Notification, NotificationChannel, NotificationStatus
 from slack_sdk.errors import SlackApiError
 
-from tests.fake_data_utils import fake
+from tests.fake_data_utils import fake, run_delete
 from pydantic import error_wrappers
 
 
@@ -18,16 +18,16 @@ def db():
 
 @pytest.fixture(autouse=True)
 def setup(db):
-    db = Session()
     yield  # this is where the testing happens
     db.rollback()
+    run_delete(Notification, db)
 
 
 class MockResponse(object):
     def __init__(self, success: bool):
         # mocks request.reponse behavior returned by SendGrid
         self.ok = success
-        self.status_code = 202
+        self.status_code = 202 if success else 500
         # mocks object from Twilio response
         self.error_code = None if success else 1234
 

--- a/api/tests/test_personal_identifiers.py
+++ b/api/tests/test_personal_identifiers.py
@@ -1,0 +1,148 @@
+from time import sleep
+import pytest
+from unittest.mock import patch
+from settings import Session
+
+from fastapi.testclient import TestClient
+from sqlalchemy import and_
+from email_validator import EmailNotValidError, validate_email
+from phonenumbers.phonenumberutil import NumberParseException
+from fastapi_jwt_auth import AuthJWT
+
+from models import Account, PersonalIdentifier, EmailIdentifier, PhoneNumberIdentifier, IdentifierType, VerificationToken
+from api.api import app
+import auth
+
+@pytest.fixture(scope='function')
+def client():
+    return TestClient(app)
+
+@pytest.fixture
+def db():
+    return Session()
+
+def test_personal_identifiers_relationships_and_polymorphism(db):
+    account = Account(first_name='Test', last_name='Success')
+
+    account_email = EmailIdentifier(value='good.email@example.com')
+    account.primary_email_identifier = account_email
+    other_email = EmailIdentifier(value='another.good.email@example.com')
+
+    account_phone_number = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+    account.primary_phone_number_identifier = account_phone_number
+    other_phone_number = PhoneNumberIdentifier(value='+1 805 334 8626')
+
+    db.add(other_email)
+    db.add(other_phone_number)
+    db.add(account)
+    db.commit()
+
+    assert account.personal_identifiers
+
+    assert other_email.account is None
+    assert other_phone_number.account is None
+
+    linked_email = account.primary_email_identifier
+    linked_phone_number = account.primary_phone_number_identifier
+    assert linked_email.uuid == account_email.uuid
+    assert linked_email in account.personal_identifiers
+    assert linked_phone_number.uuid == account_phone_number.uuid
+    assert linked_phone_number in account.personal_identifiers
+
+    email_linked_account = account_email.account
+    phone_number_linked_account = account_phone_number.account
+    assert email_linked_account.uuid == account.uuid
+    assert phone_number_linked_account.uuid == account.uuid
+
+    queried_email = db.query(PersonalIdentifier).filter(and_(PersonalIdentifier.account==account, PersonalIdentifier.type==IdentifierType.EMAIL)).first()
+    queried_phone_number = db.query(PersonalIdentifier).filter(and_(PersonalIdentifier.account==account, PersonalIdentifier.type==IdentifierType.PHONE)).first()
+    assert queried_email.uuid == account_email.uuid
+    assert queried_phone_number.uuid == account_phone_number.uuid
+
+    [db.delete(record) for record in [account, other_email, other_phone_number]]
+    db.commit()
+
+def test_email_validation():
+    good_email = EmailIdentifier(value='good.email@example.com')
+    assert good_email.value == 'good.email@example.com'
+
+    with pytest.raises(EmailNotValidError):
+        _ = EmailIdentifier(value='@not.a good email')
+
+    with pytest.raises(AssertionError):
+        account = Account(first_name=' Test', last_name='Success')
+        good_phone_number = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+        account.primary_email_identifier = good_phone_number
+
+def test_phone_number_validation():
+    good_phone_number = PhoneNumberIdentifier(value='+1 1-800-444-4444')
+    assert good_phone_number.value == '+18004444444'
+
+    with pytest.raises(NumberParseException):
+        _ = PhoneNumberIdentifier(value='987325')
+
+    with pytest.raises(AssertionError):
+        account = Account(first_name=' Test', last_name='Success')
+        good_email = EmailIdentifier(value='good.email@example.com')
+        account.primary_phone_number_identifier = good_email
+
+@patch('auth.notifications_manager.send_notification')
+def test_verify_personal_identifier_without_account(mock_send, db, client):
+    begin_response = client.post(
+        'api/verify_identifier/start',
+        json = {'identifier': 'email_to_verify@example.com', 'type': 'email'}
+    )
+
+    assert begin_response.status_code == 200
+    assert begin_response.json()['verification_token_uuid']
+    assert mock_send.called
+
+    token = db.query(VerificationToken).filter(and_(PersonalIdentifier.type==IdentifierType.EMAIL, PersonalIdentifier.value=='email_to_verify@example.com')).order_by(VerificationToken.created_at.desc()).first()
+
+    finish_response = client.post(
+        'api/verify_identifier/finish',
+        json = {'verification_token_uuid': str(token.uuid), 'otp': token.otp}
+    )
+
+    assert finish_response.status_code == 200
+    assert finish_response.json() == {'msg': 'The provided token\'s personal identifier has been verified'}
+
+    db.delete(token)
+    db.commit()
+
+# Can't figure out how to mock an authenticated session
+# Not sure what magic fastapi_jwt_auth is doing here: 
+# https://github.com/IndominusByte/fastapi-jwt-auth/blob/master/tests/test_url_protected.py
+
+# @patch('auth.notifications_manager.send_notification')
+# def test_verify_personal_identifier_with_account(mock_send, db, client, Authorize):
+#     account = Account(first_name='Verification', last_name='Test')
+#     db.add(account)
+#     db.commit()
+#     jwt = Authorize.create_access_token(subject=str(account.uuid))
+
+#     begin_response = client.post(
+#         'api/verify_identifier/start',
+#         headers = {"Authorization":f"Bearer {jwt}"},
+#         json = {'identifier': 'another_email_to_verify@example.com', 'type': 'email'}
+#     )
+
+#     assert begin_response.status_code == 200
+#     assert begin_response.json()['verification_token_uuid']
+#     assert mock_send.called
+
+#     token = db.query(VerificationToken).filter(and_(PersonalIdentifier.type==IdentifierType.EMAIL, PersonalIdentifier.value=='another_email_to_verify@example.com')).order_by(VerificationToken.created_at.desc()).first()
+#     assert token.personal_identifier.account.uuid == account.uuid
+
+#     finish_response = client.post(
+#         'api/verify_identifier/finish',
+#         headers = {"Authorization":f"Bearer {jwt}"},
+#         json = {'verification_token_uuid': str(token.uuid), 'otp': token.otp}
+#     )
+
+#     assert finish_response.status_code == 200
+#     assert finish_response.json() == {'msg': 'The provided token\'s personal identifier has been verified'}
+
+#     db.delete(account)
+#     db.delete(token)
+#     db.commit()

--- a/client/src/components/VerifyAccount.js
+++ b/client/src/components/VerifyAccount.js
@@ -4,21 +4,22 @@ import { Link, Redirect } from 'react-router-dom';
 import { withCookies } from 'react-cookie';
 
 import LoadingSpinner from './LoadingSpinner';
-import { getAccountAndSettingsFromHash } from 'store/user-slice';
+import { getAccountAndSettingsFromOTP } from 'store/user-slice';
 import { startLogout } from 'store/user-slice';
 
 function VerifyAccount(props) {
   const [loading, setLoading] = useState(false);
   const [hasError, setHasError] = useState(null);
   const [canRedirect, setCanRedirect] = useState();
-  const { user, cookies, getAccountAndSettingsFromHash } = props;
+  const { user, cookies, getAccountAndSettingsFromOTP } = props;
 
   useEffect(() => {
     setLoading(true);
     const params = new URLSearchParams(window.location.search);
-    const hash = params.get('hash');
+    const token_id = params.get('token');
+    const otp = params.get('otp');
 
-    getAccountAndSettingsFromHash(hash, cookies)
+    getAccountAndSettingsFromOTP(token_id, otp, cookies)
       .then(() => {
         setTimeout(() => {
           setCanRedirect(true);
@@ -65,7 +66,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = {
   startLogout,
-  getAccountAndSettingsFromHash,
+  getAccountAndSettingsFromOTP,
 };
 
 export default withCookies(

--- a/client/src/pages/account/Profile.js
+++ b/client/src/pages/account/Profile.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 import { Button, Form, Col, Row } from 'react-bootstrap';
 import { basicPropUpdate, attemptUpdateAccount } from 'store/user-slice';
-import { AccountReqBody } from 'store/user-slice/classes';
+import { AccountBody } from 'store/user-slice/classes';
 import useForm from 'components/hooks/useForm';
 import { isEqual } from 'lodash';
 
@@ -279,7 +279,7 @@ function Profile(props) {
         </Row>
         <Row
           className={
-            isEqual(new AccountReqBody(user), new AccountReqBody(data))
+            isEqual(new AccountBody(user), new AccountBody(data))
               ? 'd-none'
               : null
           }

--- a/client/src/pages/account/Settings.js
+++ b/client/src/pages/account/Settings.js
@@ -117,7 +117,7 @@ function Settings(props) {
             />
           </Col>
         </Row>
-        <Form.Group className={user.oauth ? 'd-none' : null}>
+        <Form.Group className={user.primary_identifier_type == 'email' ? null : 'd-none'}>
           <div className={'mt-3 ' + (data.oldPass ? 'mb-5' : 'mb-4')}>
             <Form.Label>Change Password</Form.Label>
             <Form.Control

--- a/client/src/store/user-slice/classes.js
+++ b/client/src/store/user-slice/classes.js
@@ -1,17 +1,28 @@
-export class AccountReqBody {
+export class AccountBody {
   constructor(obj) {
     this.username = obj.username;
-    this.email = obj.email;
     this.first_name = obj.first_name;
     this.last_name = obj.last_name;
-    this.password = obj.password;
-    this.oauth = obj.oauth;
     this.profile_pic = obj.profile_pic;
     this.city = obj.city;
     this.state = obj.state;
     this.zip_code = obj.zip_code;
     this.roles = obj.roles || [];
-    this.is_verified = obj.is_verified || false;
+  }
+}
+
+export class Identifier {
+  constructor(obj) {
+    this.identifier = obj.identifier;
+    this.type = obj.type;
+  }
+}
+
+export class AccountCreateReqBody {
+  constructor(obj) {
+    this.account = new AccountBody(obj.account);
+    this.identifier = new Identifier(obj.identifier);
+    this.password = obj.password;
   }
 }
 

--- a/client/src/store/user-slice/helpers.js
+++ b/client/src/store/user-slice/helpers.js
@@ -21,7 +21,7 @@ export const validateEmail = (email) => {
   const isValid = regex.test(String(email).toLowerCase());
   return isValid
     ? null
-    : 'Please provide a valid e-mail address (i.e. andy@test.com)';
+    : 'Please provide a valid e-mail address (e.g. andy@test.com)';
 };
 
 export const validateUsername = (username) => {

--- a/client/src/store/user-slice/index.js
+++ b/client/src/store/user-slice/index.js
@@ -230,7 +230,6 @@ export const attemptRegister = (payload) => async (dispatch) => {
 
   try {
     sanitizeData(payload);
-    console.log(payload);
     let request = { account: payload,
       identifier: { identifier: payload.email,
         type: 'email'},
@@ -408,9 +407,6 @@ export const getAccountAndSettingsFromOTP = (token_id, otp, cookies) => async (
       `/api/verify_identifier/finish?token=${token_id}&otp=${otp}`
     );
     const account = { ...userRes.data.account };
-    console.log("AAAAAApAAA");
-    console.log(userRes);
-    console.log(account);
     const refreshTime = Date.now();
     dispatch(setRefreshTime(refreshTime));
     dispatch(setUser(account));

--- a/client/src/store/user-slice/reset-password.js
+++ b/client/src/store/user-slice/reset-password.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { AccountReqBody, SettingsReqBody } from './classes';
+import { AccountBody, SettingsReqBody } from './classes';
 import {
   validatePassword,
   validateEmail,
@@ -54,10 +54,7 @@ export const attemptResetPassword = async (payload) => {
     if (formHasNoErrors(errors)) {
       sanitizeData(password);
       await axios.patch(
-        `/api/accounts/${uuid}`,
-        new AccountReqBody({
-          password,
-        })
+        `/api/accounts/${uuid}`, { password: password }
       );
       await resetPasswordAndInfo(uuid);
       return;

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -46,7 +46,8 @@ CREATE TYPE public.identifiertype AS ENUM (
     'EMAIL',
     'PHONE',
     'SLACK_ID',
-    'GOOGLE_ID'
+    'GOOGLE_ID',
+    'GITHUB_ID'
 );
 
 
@@ -111,6 +112,26 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: account_settings; Type: TABLE; Schema: public; Owner: admin
+--
+
+CREATE TABLE public.account_settings (
+    uuid uuid NOT NULL,
+    account_uuid uuid,
+    show_name boolean NOT NULL,
+    show_email boolean NOT NULL,
+    show_location boolean NOT NULL,
+    organizers_can_see boolean NOT NULL,
+    volunteers_can_see boolean NOT NULL,
+    initiative_map json NOT NULL,
+    password_reset_hash text,
+    password_reset_time timestamp without time zone
+);
+
+
+ALTER TABLE public.account_settings OWNER TO admin;
+
+--
 -- Name: accounts; Type: TABLE; Schema: public; Owner: admin
 --
 
@@ -119,25 +140,18 @@ CREATE TABLE public.accounts (
     username character varying(255),
     first_name character varying(255),
     last_name character varying(255),
+    password text,
+    profile_pic text,
+    city character varying(32),
+    state character varying(32),
+    roles character varying[] NOT NULL,
+    zip_code character varying(32),
     _primary_email_identifier_uuid uuid,
     _primary_phone_number_identifier_uuid uuid
 );
 
 
 ALTER TABLE public.accounts OWNER TO admin;
-
---
--- Name: donation_emails; Type: TABLE; Schema: public; Owner: admin
---
-
-CREATE TABLE public.donation_emails (
-    donation_uuid uuid NOT NULL,
-    email text,
-    request_sent_date timestamp without time zone
-);
-
-
-ALTER TABLE public.donation_emails OWNER TO admin;
 
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: admin
@@ -262,18 +276,18 @@ CREATE TABLE public.volunteer_openings (
 ALTER TABLE public.volunteer_openings OWNER TO admin;
 
 --
--- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: admin
+-- Data for Name: account_settings; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.accounts (uuid, username, first_name, last_name, _primary_email_identifier_uuid, _primary_phone_number_identifier_uuid) FROM stdin;
+COPY public.account_settings (uuid, account_uuid, show_name, show_email, show_location, organizers_can_see, volunteers_can_see, initiative_map, password_reset_hash, password_reset_time) FROM stdin;
 \.
 
 
 --
--- Data for Name: donation_emails; Type: TABLE DATA; Schema: public; Owner: admin
+-- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.donation_emails (donation_uuid, email, request_sent_date) FROM stdin;
+COPY public.accounts (uuid, username, first_name, last_name, password, profile_pic, city, state, roles, zip_code, _primary_email_identifier_uuid, _primary_phone_number_identifier_uuid) FROM stdin;
 \.
 
 
@@ -282,20 +296,20 @@ COPY public.donation_emails (donation_uuid, email, request_sent_date) FROM stdin
 --
 
 COPY public.events (id, airtable_last_modified, updated_at, is_deleted, uuid, event_name, event_graphics, signup_link, start, "end", description) FROM stdin;
-9181734156469	2021-04-03 23:32:40.41549	2021-04-06 23:32:40.41549	f	765ef0ea-975f-45b0-9090-d898ac36b763	Let open your name eat science away throughout.	{}	https://www.olson.com/login.htm	2021-04-13 23:32:40.41549	2021-04-17 23:32:40.41549	Mother since threat yeah if customer may. Ball fish land need standard interest cup.
-9133694445589	2021-04-09 23:32:40.416249	2021-04-13 23:32:40.416249	f	eb7a529d-6e71-49f8-b7b1-fe62ce903e20	Way on guess candidate walk goal.	{}	https://short.com/tags/blog/blog/homepage/	2021-04-20 23:32:40.416249	2021-04-22 23:32:40.416249	Adult age lead military morning race car fall. When fund themselves north new.
-2581979348006	2021-04-03 23:32:40.416702	2021-04-08 23:32:40.416702	f	06488894-74f2-4f80-ab70-b56bcd04bb35	Lawyer soldier number tough.	{}	https://mcdowell.info/blog/tag/list/author.php	2021-04-15 23:32:40.416702	2021-04-23 23:32:40.416702	Material most seven field art. Long along serious suggest thought. Company well window concern friend teacher body.
-1596770131338	2021-04-06 23:32:40.416943	2021-04-10 23:32:40.416943	f	4d9be9a1-3468-4add-a41e-f29fea9e5c9b	Wear whom fish mission assume home.	{}	http://erickson.biz/	2021-04-16 23:32:40.416943	2021-04-17 23:32:40.416943	Take state which day bill organization stage respond. Recently attack total rise.
-3504292223866	2021-04-04 23:32:40.417239	2021-04-09 23:32:40.417239	f	11b69a0f-82ac-4192-a92d-8b2b4fc96aa9	First pass specific treatment.	{"{\\"url\\": \\"https://placekitten.com/625/700\\"}"}	http://moore.com/explore/faq.asp	2021-04-15 23:32:40.417239	2021-04-19 23:32:40.417239	Us son least little able democratic. Cultural pass quality those reflect accept certainly measure. Under sure discuss main next activity. Article right up.
-4399040967623	2021-03-30 23:32:40.423314	2021-04-03 23:32:40.423314	f	7e8689a5-f16c-4640-8f4f-d8f3af6e0652	State one sign next my.	{"{\\"url\\": \\"https://dummyimage.com/999x119\\"}"}	https://jimenez-hughes.net/	2021-04-11 23:32:40.423314	2021-04-20 23:32:40.423314	Send will page start moment. Impact speech the over score available. Real check choose.
-5815602681619	2021-03-26 23:32:40.42362	2021-03-29 23:32:40.42362	f	b1e01c06-e944-46bf-8954-7d875bc41150	Responsibility boy responsibility forward consumer stage.	{"{\\"url\\": \\"https://www.lorempixel.com/338/247\\"}"}	https://fields-zimmerman.net/main.php	2021-04-06 23:32:40.42362	2021-04-14 23:32:40.42362	Skill couple would consider set method threat. School culture last work. Room though issue top military pull. Our since relationship and now.
-9935535402078	2021-04-03 23:32:40.423928	2021-04-09 23:32:40.423928	f	db76aa87-17ed-4956-af9a-2d554deec219	Mother trade station actually sign.	{}	https://fields.info/terms.php	2021-04-15 23:32:40.423928	2021-04-22 23:32:40.423928	Bank develop may should road consumer analysis. Something responsibility friend kind tax toward successful. Fall what lot onto north.
-6347556701017	2021-03-29 23:32:40.425924	2021-04-01 23:32:40.425924	f	ca5028f0-3345-452d-ac64-ff3eaf3f95ef	It campaign example increase argue.	{"{\\"url\\": \\"https://www.lorempixel.com/801/496\\"}"}	https://martinez.com/search/	2021-04-09 23:32:40.425924	2021-04-13 23:32:40.425924	Sea hospital let especially campaign quickly. Impact should them. Improve believe magazine as a around available.
-1588888179784	2021-03-22 23:32:40.426222	2021-03-24 23:32:40.426222	f	248f610f-e21c-41bf-882b-0ea82bd9d0fc	Firm pay nation situation onto.	{"{\\"url\\": \\"https://www.lorempixel.com/180/660\\"}"}	https://www.morales.com/search/tags/tag/terms.html	2021-04-01 23:32:40.426222	2021-04-05 23:32:40.426222	Forward even car force bring. Require cup case million hour must. Prove nation knowledge fall.
-7089376165035	2021-04-06 23:32:40.426676	2021-04-11 23:32:40.426676	f	05019869-de6d-4882-b3bd-ff1da189de79	Create half market.	{}	http://www.jackson-lopez.com/homepage.php	2021-04-17 23:32:40.426676	2021-04-21 23:32:40.426676	These small stand around. Involve bank hundred black sell as rate. Ago hold if Mr hair call seat.
-6705104007682	2021-04-07 23:32:40.428805	2021-04-12 23:32:40.428805	f	91dc8419-3bcb-47f4-ac5a-f80692a1ca08	Yard special sign compare provide trade.	{"{\\"url\\": \\"https://placeimg.com/166/607/any\\"}"}	https://www.todd-lewis.com/terms/	2021-04-19 23:32:40.428805	2021-04-20 23:32:40.428805	Military sign everything where table his machine. Live oil human dark put customer personal animal. Game service indeed picture about attention suddenly lose.
-5215914462768	2021-04-06 23:32:40.429143	2021-04-08 23:32:40.429143	f	20894885-bfae-4076-b607-79215f6a8c72	Able community raise situation yes nation.	{"{\\"url\\": \\"https://dummyimage.com/577x820\\"}"}	http://www.phillips.net/	2021-04-16 23:32:40.429143	2021-04-26 23:32:40.429143	Today describe support involve right. Clear kid agreement life very standard include between. Entire sure walk hand town game edge street.
-8246697447168	2021-04-01 23:32:40.429502	2021-04-05 23:32:40.429502	f	2b2fc679-9f14-4e61-8bfe-9610682bc85e	From theory interesting various.	{}	https://www.curry-garcia.com/index/	2021-04-13 23:32:40.429502	2021-04-17 23:32:40.429502	Baby of heart street. Mrs choose south hope price since. Stay hand character single local director civil.
+6056219346990	2021-05-16 16:35:22.898536	2021-05-19 16:35:22.898536	f	da791fbc-f890-4980-83cd-6baac00b08d8	Special site see determine pattern.	{}	http://www.oliver.info/tags/terms.html	2021-05-26 16:35:22.898536	2021-05-30 16:35:22.898536	To source notice cut rich. Raise situation gas audience. Figure early reveal yes unit see despite dark. Raise arm paper teacher product care.
+8182178994052	2021-05-22 16:35:22.899278	2021-05-26 16:35:22.899278	f	48c6dfee-f50b-41e3-a299-3388b3440890	Area which dream certainly only fund high.	{}	http://www.hayes.com/main/category/explore/login/	2021-06-02 16:35:22.899278	2021-06-04 16:35:22.899278	Down have ever laugh player market. Cost often during group. Husband morning matter issue interview month great. Nature game once.
+0395096938253	2021-05-16 16:35:22.900084	2021-05-21 16:35:22.900084	f	d3439319-47f2-4726-9ead-ffaec017eb97	Money court part message mind green.	{}	https://www.tapia-reed.com/author/	2021-05-28 16:35:22.900084	2021-06-05 16:35:22.900084	Education organization senior mind argue anyone hair. Heart compare discover memory provide. True respond nor apply would western. Kind air local he player watch.
+4494023330521	2021-05-19 16:35:22.90069	2021-05-23 16:35:22.90069	f	6f70b97a-2c64-49b1-96d7-237f39f8a904	Reality middle young south think wrong.	{}	https://cochran.com/	2021-05-29 16:35:22.90069	2021-05-30 16:35:22.90069	Give his traditional key traditional over. Return small fast operation. Campaign individual certain here. Program sound day employee education level glass.
+3388510052694	2021-05-17 16:35:22.901494	2021-05-22 16:35:22.901494	f	e10ef625-d3c9-4c6b-93e0-d6c767afd52b	Pretty yard public country when.	{"{\\"url\\": \\"https://placeimg.com/38/667/any\\"}"}	http://krueger.com/faq.html	2021-05-28 16:35:22.901494	2021-06-01 16:35:22.901494	Energy woman sea ready. List price most exist. Five yes boy these hard guess man by.
+4551178791970	2021-05-12 16:35:22.911349	2021-05-16 16:35:22.911349	f	d5545420-5a1c-4dfb-91b0-39aa9afd7c22	Candidate four read public describe stay.	{"{\\"url\\": \\"https://placeimg.com/973/930/any\\"}"}	http://kim-boyd.org/category/about/	2021-05-24 16:35:22.911349	2021-06-02 16:35:22.911349	Cup growth race move. Black author ok build money. Figure professional serious eye.
+5665975233416	2021-05-08 16:35:22.911948	2021-05-11 16:35:22.911948	f	d4e11969-b49a-4e4a-9245-c6fd9e1f42d3	Movement pull administration some share knowledge left first.	{"{\\"url\\": \\"https://placeimg.com/767/866/any\\"}"}	https://www.ortiz.com/main/	2021-05-19 16:35:22.911948	2021-05-27 16:35:22.911948	Role wife wife myself team along. Compare there few whatever must before. Social road story several few. Trade tonight program trial beyond democratic.
+2047234397443	2021-05-16 16:35:22.912565	2021-05-22 16:35:22.912565	f	683f49ae-76ad-4311-a0b1-c276d5aa1a31	Yeah reason individual road center.	{}	https://lewis.info/terms/	2021-05-28 16:35:22.912565	2021-06-04 16:35:22.912565	Suddenly six discover relate trial stock. Be specific give life debate name. Argue else need long. Building offer task ready mother soon.
+1109967297412	2021-05-11 16:35:22.916334	2021-05-14 16:35:22.916334	f	a194e421-59b6-49a7-b066-3518908cd1b9	Around start after north.	{"{\\"url\\": \\"https://placeimg.com/591/382/any\\"}"}	https://wood.org/categories/list/search.php	2021-05-22 16:35:22.916334	2021-05-26 16:35:22.916334	Need to will throw speech charge. Hit among six push compare. Sell else bag country artist later bar with. Walk stand true reality provide. Author shake phone answer I.
+1670048705213	2021-05-04 16:35:22.917011	2021-05-06 16:35:22.917011	f	528c906c-e590-46cb-9a24-b35bb5527865	Simple mission dog good thousand indicate.	{"{\\"url\\": \\"https://dummyimage.com/805x613\\"}"}	https://miranda.info/tags/search/post/	2021-05-14 16:35:22.917011	2021-05-18 16:35:22.917011	Structure hundred concern which item buy. Short once son throughout light sure art. Side I specific might.
+5270547114286	2021-05-19 16:35:22.917639	2021-05-24 16:35:22.917639	f	01b2ad96-5459-442d-aa63-66dc34cabaf7	Even past without much.	{}	https://collins.com/	2021-05-30 16:35:22.917639	2021-06-03 16:35:22.917639	Suddenly public evidence he hundred rest. Determine establish wear piece. Entire forward land common remember mouth.
+5303929509216	2021-05-20 16:35:22.921126	2021-05-25 16:35:22.921126	f	5373562a-c806-445f-90c3-c8c0096b5235	Training north bill if control in lot strategy.	{"{\\"url\\": \\"https://dummyimage.com/212x98\\"}"}	http://www.mills.com/homepage.html	2021-06-01 16:35:22.921126	2021-06-02 16:35:22.921126	Deal education shake from address leave. Summer democratic half station. Her focus billion employee.
+5347920879275	2021-05-19 16:35:22.921504	2021-05-21 16:35:22.921504	f	2f0c2668-df72-4435-adad-0848f552103f	Figure establish month outside trouble job.	{"{\\"url\\": \\"https://www.lorempixel.com/867/495\\"}"}	http://franklin.com/faq/	2021-05-29 16:35:22.921504	2021-06-08 16:35:22.921504	Structure whether political decision. Care company seat six fly number model. Buy police base. Travel side morning yeah protect third. Far gas art available add on meeting.
+9183419837625	2021-05-14 16:35:22.922247	2021-05-18 16:35:22.922247	f	fa8f236b-bbb9-4461-a795-38faa6211e0d	Really sort simply culture.	{}	http://www.jones-blanchard.com/about/	2021-05-26 16:35:22.922247	2021-05-30 16:35:22.922247	White claim blood chance bad writer. Simply discussion all though he meeting worker suggest. Way myself mother strong gun national policy. East thus method TV season. Truth resource road down man.
 \.
 
 
@@ -304,9 +318,9 @@ COPY public.events (id, airtable_last_modified, updated_at, is_deleted, uuid, ev
 --
 
 COPY public.initiatives (id, airtable_last_modified, updated_at, is_deleted, uuid, initiative_name, "order", details_link, hero_image_urls, description, roles, events) FROM stdin;
-0397370105740	2021-03-27 23:32:40.424212	2021-04-01 23:32:40.424212	f	0a472acc-6430-4c3b-ac31-b9b72b55cf90	Noah Williams	1	http://fleming.com/explore/main/tag/homepage.htm	{"{\\"url\\": \\"https://www.lorempixel.com/558/1004\\"}"}	Eight traditional break decide produce anything. Tv thought together yard sister voice plant. Authority view yeah according station.	{4826765665621,6286439111737}	{4399040967623,5815602681619,9935535402078}
-2822606960599	2021-04-10 23:32:40.426966	2021-04-13 23:32:40.426966	f	5ea19b96-d676-4ad9-896f-ab98ab0ac351	Eduardo Manning	2	http://www.alvarez.com/tags/category/search/	{"{\\"url\\": \\"https://www.lorempixel.com/725/880\\"}"}	Final spend each start put each drug. Forget system country know personal wife. Practice senior us rule. Option front must on.	{3089101928878,4245214338129}	{6347556701017,1588888179784,7089376165035}
-3235400700169	2021-03-31 23:32:40.429836	2021-04-04 23:32:40.429836	f	5858e172-776e-4f3e-b049-ad7aba7c35ee	Mary Arellano	3	http://nash.com/posts/app/tag/home.php	{}	Treat require everyone near ground dark suddenly. Listen statement not itself contain program.	{8584738251375,3541688610077}	{6705104007682,5215914462768,8246697447168}
+2361157123140	2021-05-09 16:35:22.913257	2021-05-14 16:35:22.913257	f	9c04e10e-7b4d-4ac5-9873-dd4cc8b6217a	Logan Clark	1	http://white.org/blog/categories/explore/homepage/	{"{\\"url\\": \\"https://dummyimage.com/663x132\\"}"}	Score tough later card push couple become. Another heavy half site area keep. Bag whole possible century. Particular price represent expect program least fast great. Student bill she economy old discuss turn.	{7275824548264,4533740455879}	{4551178791970,5665975233416,2047234397443}
+6672516079838	2021-05-23 16:35:22.918049	2021-05-26 16:35:22.918049	f	f20e5ea2-e80a-4674-9a1b-2d34e5375d50	Deborah Carr	2	http://www.jackson-warren.com/explore/author/	{"{\\"url\\": \\"https://dummyimage.com/304x959\\"}"}	Plan name skill method wall result manager argue. Law hold medical her after per nothing. Bad plan letter pressure example onto. Piece tough always for away.	{1136740998334,8346566011824}	{1109967297412,1670048705213,5270547114286}
+4507130976640	2021-05-13 16:35:22.92272	2021-05-17 16:35:22.92272	f	6eb4b797-e5ea-49c6-940b-a1a879210d3b	Jaime Beard	3	https://www.ingram-brown.info/register/	{}	Skin century religious bag reality worker. Word reveal share score modern on. Letter whose shoulder. Evening action example reach old serious center.	{8232648857346,0617474511095}	{5303929509216,5347920879275,9183419837625}
 \.
 
 
@@ -339,18 +353,26 @@ COPY public.verification_tokens (uuid, created_at, already_used, counter, person
 --
 
 COPY public.volunteer_openings (id, airtable_last_modified, updated_at, is_deleted, uuid, role_name, hero_image_urls, application_signup_form, more_info_link, priority, team, team_lead_ids, num_openings, minimum_time_commitment_per_week_hours, maximum_time_commitment_per_week_hours, job_overview, what_youll_learn, responsibilities_and_duties, qualifications, role_type) FROM stdin;
-6753523204564	2021-04-02 23:32:40.40516	2021-04-07 23:32:40.40516	f	f6108601-c08a-4f21-9f81-1168b2027acf	Degree attention bag over.	{"{\\"url\\": \\"https://www.lorempixel.com/381/862\\"}"}	https://johnson.com/terms.htm	https://gilbert.com/categories/tags/login/	MEDIUM	{8725400549875}	{}	6	2	8	Seem use involve news. Report risk writer growth class shoulder ahead general. Ten father professor mouth visit state artist.	Discuss report half stock dark pick. Cultural will laugh box guess country leader media. Human thought remember strategy time.	Audience by second likely purpose since. Task face can. Direction couple step wait on. Half how size general. Character war large eye.	Ask do occur form matter test. Red blue choice ok. Management camera body decision.	REQUIRES_APPLICATION
-3780349975791	2021-03-26 23:32:40.406024	2021-03-29 23:32:40.406024	f	c9b16171-e712-4995-8f3d-cefc1f833952	Sense guy need candidate.	{"{\\"url\\": \\"https://dummyimage.com/795x587\\"}"}	https://www.price-hayden.com/wp-content/wp-content/explore/search.html	http://www.smith.com/	MEDIUM	{9389107162714}	{3532321164606}	6	8	4	Finally term capital during one. Race floor wear member nature cell rock. Better and conference million. Investment peace on home year during coach. Expect move center both enough director.	Bring poor by sound name common. Want foreign reason fast which. Instead production hit morning low short tree him. Identify skill couple base inside pretty difficult study. Tough above important or exactly deep through.	Thus wait finish during our smile. Player popular deep baby. Professional they success eight. Be team wait rock color.	Truth fish paper great. Face likely amount former happen your daughter. Important despite act recently hold type TV. Red score mention step mention include would.	OPEN_TO_ALL
-9006898382939	2021-03-27 23:32:40.40686	2021-03-29 23:32:40.40686	f	2b52707b-c84e-4dee-ad7c-1dae4d1b96f0	Ball himself beautiful brother word respond lead interesting.	{"{\\"url\\": \\"https://placekitten.com/462/550\\"}"}	https://hogan.biz/app/faq.htm	http://yoder.net/home.jsp	MEDIUM	{2370183504663}	{}	3	8	7	Window beautiful thank need stop onto partner. Set nation general.	Will more western bank here easy. Of mission participant. Prove law hand result. Everyone price church sit win after certainly. Mission threat government remember idea.	Bill state might main. Perhaps late economic put bank. Sell teach beautiful side organization.	Environmental experience mouth instead tree letter operation. Loss trade leg seven. Fast join tonight blue remember college past. Sing throw prevent writer see set administration.	REQUIRES_APPLICATION
-0609833533626	2021-04-05 23:32:40.407609	2021-04-09 23:32:40.407609	f	848e8854-64a5-455f-a903-ff575472ba9b	Together professor almost impact central thousand teach somebody.	{"{\\"url\\": \\"https://dummyimage.com/331x283\\"}"}	https://morrison.com/register/	https://www.rios.info/search/	MEDIUM	{9371874618594}	{7276105513803}	2	5	3	Arm skin interest organization away ago teach. Approach information write good data forget sign. He business arm should call face wife phone.	Top adult rule forward. Air sport right five figure capital.	Church lawyer argue who such key million. Day upon either better. That form true decision meeting. Prepare about goal say ball music drug east.	Fight office organization month without. Rate work thought yet. Garden prevent manager such play even. Determine against wide gun return majority prove. Our them determine total money.	OPEN_TO_ALL
-6217013592956	2021-04-01 23:32:40.408163	2021-04-04 23:32:40.408163	f	4e1a1e64-33a4-4bca-a5cf-420146ec19b6	Pressure soldier each there good.	{"{\\"url\\": \\"https://placekitten.com/791/909\\"}"}	https://wilson.com/explore/app/wp-content/homepage.html	https://eaton.com/categories/faq/	MEDIUM	{4464737391231}	{}	5	9	9	Later mouth mean. Impact character along.	Pattern together ok resource. Measure trade team treat boy hand memory. Us himself investment brother student low foreign much. She same score like.	Group partner job audience. Never surface west law manager though. Bar less store note same. Agent site none little imagine state official.	Mission then blood white site situation down. Address PM property ago commercial which not. Society hand phone radio bag suggest last.	REQUIRES_APPLICATION
-4826765665621	2021-04-01 23:32:40.421698	2021-04-05 23:32:40.421698	f	a909a1d1-b1fc-4b3b-bed7-c32907795222	Traditional man collection special type clearly between.	{"{\\"url\\": \\"https://placekitten.com/799/423\\"}"}	https://hernandez.com/	http://lopez-pope.biz/	MEDIUM	{8960643281254}	{1231520782520}	3	9	6	Computer conference result. Trial admit me single yes conference contain there. Money red goal begin he professor range. She walk mind black. Candidate on everything bit reveal who anyone language.	It hear attention white. Visit poor front.	Too about budget mouth this commercial two. Consumer card general marriage less whose agreement.	Want brother important remember data receive. Sometimes picture security training big. Form if forward career. Better environmental region business others consider.	OPEN_TO_ALL
-6286439111737	2021-04-05 23:32:40.422563	2021-04-09 23:32:40.422563	f	5b473aa8-db81-4ebe-9d2e-b8146229e446	Major relate name contain.	{"{\\"url\\": \\"https://dummyimage.com/787x147\\"}"}	https://www.davis.com/	https://www.hammond-hurley.com/tag/register/	MEDIUM	{8346826433793}	{}	2	4	4	Tend decision of couple country chance find. Action data fight. Support billion soldier cover. West executive skill commercial.	Hair form notice upon suddenly. Fine good rule foreign or point. Population fish these anything.	Marriage brother partner rest represent. Eight decide chair development challenge. Compare particular against on note successful pressure.	Practice guy laugh the whether miss camera. Movie head last early long. Character ball garden indicate pattern. Agreement defense firm ability he budget.	OPEN_TO_ALL
-3089101928878	2021-03-24 23:32:40.424585	2021-03-29 23:32:40.424585	f	418bdde9-8132-4a47-b4eb-84c157852c68	Party actually movie knowledge particular whom.	{"{\\"url\\": \\"https://placeimg.com/750/831/any\\"}"}	https://www.boyd.info/category/search/search/login.htm	http://www.diaz-reyes.org/faq.html	MEDIUM	{4761654764644}	{0286775226917}	3	9	5	Tv score direction down else. Back low Mr. Central follow system will. Resource word open let director care some.	Institution black require those imagine after. Smile case should choose kind how party.	Difficult manage future. Stand unit learn avoid onto. Unit whose official door before station surface.	Education away perhaps mother. And someone pull college teach report ability. Job piece ago foot world. Set baby similar. Old because quickly.	REQUIRES_APPLICATION
-4245214338129	2021-03-25 23:32:40.425323	2021-03-28 23:32:40.425323	f	a53a6481-5567-4c9b-b2a7-7d19d64b9dce	Spend myself behavior property.	{"{\\"url\\": \\"https://placekitten.com/156/231\\"}"}	https://www.lawson.com/tags/index.php	http://www.dunn.com/tags/posts/list/search/	MEDIUM	{0696447362483}	{4959417060328}	3	3	6	Thought few assume show rate candidate. Region main land agency laugh on draw. Chance right country often very Democrat. Degree back source various work full you chance. Step a consumer politics reality capital none remember.	Pattern perform never. Star hour white outside yet own general red. Allow newspaper recently operation discussion.	Item some yeah. Card walk tonight important hand discover choose consumer. Agent hope air contain.	Across learn some on. Top agree listen section. American PM blue various. Discussion today whom hair include activity man wait.	REQUIRES_APPLICATION
-8584738251375	2021-04-10 23:32:40.427514	2021-04-13 23:32:40.427514	f	2bf3e55f-93ad-4138-b982-3b0fa1807546	Artist main sure itself strategy with.	{"{\\"url\\": \\"https://placekitten.com/836/200\\"}"}	https://www.davidson.org/posts/main/categories/author/	http://andrews-thompson.info/home/	MEDIUM	{3733355392946}	{}	2	8	5	Short already Mrs raise floor. Ground claim admit cup several guy rule street. Lose ok table several tonight. Forward field maintain table. Change information exactly crime send.	Trial smile sister know baby two fine her. Republican state budget. Better friend fact pretty resource peace maintain. Figure general officer treatment account.	Crime Congress sing may. Energy successful land. Success source white. Indeed building citizen yet good.	Once group feel seek. Population land realize despite. Difficult no dream travel method.	REQUIRES_APPLICATION
-3541688610077	2021-03-25 23:32:40.428149	2021-03-29 23:32:40.428149	f	65e09669-f1d6-4720-836c-aadaa40af24a	Indeed would character well energy.	{}	http://terrell-rodriguez.net/main/search/	http://www.sanchez.com/tags/explore/list/author.asp	MEDIUM	{4246232485420}	{9084155520089}	6	4	6	Billion among by. Sense use with line lose item camera.	Keep serious skin job deal. General any chair discuss child particular specific. Job leg least record base do project seem.	Allow foreign pull sound themselves majority why. Number some fly stuff bank difficult five. Entire thing tree step structure sure cold. Present feeling very.	Radio light much total money even spring. Trip teacher blue structure oil. Organization lawyer say not human south store. With court region career.	REQUIRES_APPLICATION
+2785068837741	2021-05-15 16:35:22.878967	2021-05-20 16:35:22.878967	f	fa75a2b0-9b65-4cae-b9a4-f1f40d0ec47d	Push when group still.	{"{\\"url\\": \\"https://dummyimage.com/279x171\\"}"}	https://www.johnson.com/posts/categories/faq/	https://www.larson-gonzalez.info/wp-content/posts/terms/	MEDIUM	{6603679841727}	{}	6	2	8	Food make attention baby season ago anyone. Vote better life indicate. Environment ever after full state. Work debate for his garden benefit than.	Newspaper PM opportunity couple though where century. Present ready west indeed capital. Happy indeed parent perform onto.	Each cultural nearly. Middle two common magazine marriage case. Affect apply summer.	Can force consumer view worry international. Benefit total chair alone skin agree.	REQUIRES_APPLICATION
+1649026518916	2021-05-08 16:35:22.881509	2021-05-11 16:35:22.881509	f	4fd94e0f-4fca-43ce-99a9-0d291ae58017	Size star point mention yes special.	{"{\\"url\\": \\"https://www.lorempixel.com/334/300\\"}"}	https://oliver.com/login/	https://www.grant-johnson.com/search/wp-content/tag/faq/	MEDIUM	{7861764326637}	{8825280504190}	6	8	4	Security policy experience front. News understand people improve generation. Charge special discover here whose tree child.	Enough role popular. Man may Congress later seat. Since develop soon how before author range day. Deal red and join. Others important building maybe toward short.	Quality item idea. Support per never culture. Street professional opportunity level anyone simply remember. Couple officer maintain occur election address. Model affect go still over worry onto concern.	One Republican their hand. Training play per quickly factor in listen camera. Always great pass leave dinner. Real weight become develop chair open itself moment.	OPEN_TO_ALL
+1790771619455	2021-05-09 16:35:22.883984	2021-05-11 16:35:22.883984	f	3961be18-8b87-4d6f-9a9c-95316bf94f51	Response require Republican.	{"{\\"url\\": \\"https://placekitten.com/348/81\\"}"}	http://www.reed.com/	https://www.reed.org/privacy.asp	MEDIUM	{9649998472935}	{}	3	8	7	From mean arm again live I. Hair tax general apply trade concern director. Send reality there report much participant style. Recently certainly then production sea politics enter.	Spend letter turn around especially or happen. Change mind up radio reflect. Recently establish region difficult unit. While quality or cell training. Budget serious hundred machine during recent.	Forward lay recent recognize among. Medical kind chance marriage but research. Worry why note improve contain never strong air. Week morning language western bad think.	Example world suddenly president dream. Group establish reality may power federal. Door north task society conference sign. Cultural join do attorney natural.	REQUIRES_APPLICATION
+3745135781253	2021-05-18 16:35:22.885707	2021-05-22 16:35:22.885707	f	25caaae4-079c-4442-ad29-ae847d2bcd8f	Drive hundred half fall tell dark.	{"{\\"url\\": \\"https://placeimg.com/523/841/any\\"}"}	http://leon-jones.com/search/	https://rogers.net/app/terms/	MEDIUM	{7427255189855}	{0075992420624}	2	5	3	Yes Mrs probably see. Hand already hear other hand attack quickly next. When mean computer.	Election election usually source sit eight. Threat loss employee not gun. Within pick including provide.	Area environment artist focus especially yet. Risk rise treat decide. Campaign father note visit six. Notice compare form tend career memory as. Anything law term send.	Night those national off. Center cultural baby. Walk bit beyond move wear best. Exactly source break history.	OPEN_TO_ALL
+4801442564091	2021-05-14 16:35:22.888027	2021-05-17 16:35:22.888027	f	e44221e0-66fb-4311-bf3e-3758b9506e4d	Painting likely rock weight though perform later.	{"{\\"url\\": \\"https://placekitten.com/1014/50\\"}"}	http://anderson.com/post.htm	https://www.sanchez.com/categories/tags/blog/index.php	MEDIUM	{8522433979088}	{}	5	9	9	Manager science play person. Bill why page woman local quality listen.	Tree policy southern difficult chair. Behind and fund sing prevent skin. Store member sport resource.	Happy decision must wonder son form yes. Better party size conference college factor. Throw quality reduce century. Red catch yes add.	More drug worker grow. Family call case eye its summer. Ability full finish hard place condition return fast. Usually appear sister produce evidence. Chair the ok action could.	REQUIRES_APPLICATION
+7275824548264	2021-05-14 16:35:22.908151	2021-05-18 16:35:22.908151	f	d50a2a7c-90ea-4607-836f-87351d7889d5	No administration politics friend send.	{"{\\"url\\": \\"https://www.lorempixel.com/209/103\\"}"}	http://jones.net/index/	http://www.mullins.info/home.asp	MEDIUM	{1918247850878}	{3651371264026}	3	9	6	Various although style option program of. Everyone head matter let somebody different window alone. Someone add general where what hand discover. History citizen fill test home team plan. Wish carry chair indeed resource indicate.	Outside himself space gas send above hand cultural. Investment include face high hundred me add.	Significant paper might or art hold. Rock top face scientist.	Material bit bit month yeah. Join mother eye stop involve begin about. Trip into material collection cold thought list. Author herself before computer person move cup. Be follow history class bit.	OPEN_TO_ALL
+4533740455879	2021-05-18 16:35:22.909937	2021-05-22 16:35:22.909937	f	04eb5388-227c-4849-9eb6-3a4aab55a653	About point sign her but.	{"{\\"url\\": \\"https://www.lorempixel.com/39/786\\"}"}	http://www.mcdonald.com/post/	http://www.curtis-rice.com/terms.htm	MEDIUM	{7223832721612}	{}	2	4	4	Radio never our gun hot. Call nor late reach single. Impact already exist individual security political. Goal catch friend entire surface sing somebody. Think really story floor show city allow.	Development more system determine listen Congress teach. Bank already level seven. Their five have floor perform share. Executive eat personal smile. Order lay science trade address reduce energy.	Attack list relate oil. Perhaps take mouth myself guess sure I rather. Television mission project enjoy.	Get wrong specific participant best after. Represent yeah easy kind. Space theory determine during voice sure. Rise expert parent amount entire themselves.	OPEN_TO_ALL
+1136740998334	2021-05-06 16:35:22.914007	2021-05-11 16:35:22.914007	f	bfc5d39e-44f0-4b24-961e-95a3c144ebf0	Company how I laugh half marriage.	{"{\\"url\\": \\"https://www.lorempixel.com/728/766\\"}"}	http://www.wolfe.net/index.htm	http://www.ayala.info/	MEDIUM	{3863036736353}	{0382987838662}	3	9	5	They relate think dinner public space live edge. Save media one alone end foot total. Simple health agree wife these fly of. Suffer couple travel discover. Do thought chair finally.	Water state expert what individual several table. Score establish want vote enjoy become last. Dark only quality kind group sound.	Really when news protect if card defense college. Buy sister property contain record lead. Time through store.	National side center activity. Whose contain various field sign.	REQUIRES_APPLICATION
+8346566011824	2021-05-07 16:35:22.915084	2021-05-10 16:35:22.915084	f	cd871d12-ebb3-435c-a2e6-e0aeb004bbce	Responsibility outside billion politics.	{"{\\"url\\": \\"https://www.lorempixel.com/726/667\\"}"}	https://perez.com/blog/main/list/terms/	https://olson-thomas.com/index/	MEDIUM	{5091666129063}	{6069177930828}	3	3	6	Involve manager investment us big. Turn country second us evening compare. Whether green my ask investment society. Someone ground pressure.	Soon put school appear. Put morning dark. World get enter animal college once fear positive. Activity wonder outside current worry action old.	Only themselves water last establish indeed phone arm. Reach design go. Major remain cell structure high her low career. Conference out thousand magazine challenge under page.	First short present cell sit know present huge. Focus people weight.	REQUIRES_APPLICATION
+8232648857346	2021-05-23 16:35:22.918859	2021-05-26 16:35:22.918859	f	795bc192-cd71-4b91-8ef8-b9929b8c5dfb	These case heavy play necessary next.	{"{\\"url\\": \\"https://placeimg.com/837/894/any\\"}"}	https://www.pierce.org/homepage.php	https://www.henderson-gomez.org/	MEDIUM	{6245872965468}	{}	2	8	5	Order cell move yeah hundred particularly American. Least just when hold Mrs mind today. Build never hand already partner wish. Recent really work still.	Off then building art such. Involve spring clearly return sign. Rather table quite sense since. Church sense thought memory week PM.	Really because list both. Fine though artist land paper name. Popular month analysis mind. All source parent both hit.	Exactly kitchen explain. Compare federal crime any real when really. National others from central daughter maintain still. Actually next fish compare behind politics. Southern source easy become.	REQUIRES_APPLICATION
+0617474511095	2021-05-07 16:35:22.920104	2021-05-11 16:35:22.920104	f	fa08f289-5d95-4985-9cda-a7bcab476846	Simply gas growth art remember article direction.	{}	http://www.carter-walters.com/explore/post.html	http://www.payne.com/author.html	MEDIUM	{1106300763887}	{0838137848123}	6	4	6	Cultural natural seven he. Despite their hold paper remember reveal natural thing. Family guy type success call.	Speech shake go table easy good. Whole bit reason husband wear character eye. Size always describe. Cell spring less music gun worry. Evening try Mrs dream process.	Behavior question front federal bar commercial newspaper each. Official level can lot arm share health. Agent great large remain than reality. Pass body baby reason nothing.	Talk effect prepare candidate among upon together. Scientist wonder recent push inside price order. Order check television lay side.	REQUIRES_APPLICATION
 \.
+
+
+--
+-- Name: account_settings account_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.account_settings
+    ADD CONSTRAINT account_settings_pkey PRIMARY KEY (uuid);
 
 
 --
@@ -362,11 +384,19 @@ ALTER TABLE ONLY public.accounts
 
 
 --
--- Name: donation_emails donation_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+-- Name: accounts accounts_username_key; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
-ALTER TABLE ONLY public.donation_emails
-    ADD CONSTRAINT donation_emails_pkey PRIMARY KEY (donation_uuid);
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts_username_key UNIQUE (username);
+
+
+--
+-- Name: events events_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_id_key UNIQUE (id);
 
 
 --
@@ -375,6 +405,14 @@ ALTER TABLE ONLY public.donation_emails
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: initiatives initiatives_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.initiatives
+    ADD CONSTRAINT initiatives_id_key UNIQUE (id);
 
 
 --
@@ -402,6 +440,14 @@ ALTER TABLE ONLY public.personal_identifiers
 
 
 --
+-- Name: personal_identifiers personal_identifiers_type_value_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.personal_identifiers
+    ADD CONSTRAINT personal_identifiers_type_value_key UNIQUE (type, value);
+
+
+--
 -- Name: verification_tokens verification_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
@@ -410,11 +456,55 @@ ALTER TABLE ONLY public.verification_tokens
 
 
 --
+-- Name: volunteer_openings volunteer_openings_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.volunteer_openings
+    ADD CONSTRAINT volunteer_openings_id_key UNIQUE (id);
+
+
+--
 -- Name: volunteer_openings volunteer_openings_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
 ALTER TABLE ONLY public.volunteer_openings
     ADD CONSTRAINT volunteer_openings_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: ix_account_uuid; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_account_uuid ON public.personal_identifiers USING hash (account_uuid);
+
+
+--
+-- Name: ix_event_id; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_event_id ON public.events USING hash (id);
+
+
+--
+-- Name: ix_role_id; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_role_id ON public.volunteer_openings USING hash (id);
+
+
+--
+-- Name: ix_value; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_value ON public.personal_identifiers USING hash (value);
+
+
+--
+-- Name: account_settings account_settings_account_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.account_settings
+    ADD CONSTRAINT account_settings_account_uuid_fkey FOREIGN KEY (account_uuid) REFERENCES public.accounts(uuid);
 
 
 --

--- a/db/data/dev/data.development.sql
+++ b/db/data/dev/data.development.sql
@@ -39,6 +39,20 @@ SET client_min_messages = warning;
 SET row_security = off;
 
 --
+-- Name: identifiertype; Type: TYPE; Schema: public; Owner: admin
+--
+
+CREATE TYPE public.identifiertype AS ENUM (
+    'EMAIL',
+    'PHONE',
+    'SLACK_ID',
+    'GOOGLE_ID'
+);
+
+
+ALTER TYPE public.identifiertype OWNER TO admin;
+
+--
 -- Name: notificationchannel; Type: TYPE; Schema: public; Owner: admin
 --
 
@@ -97,48 +111,33 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: account_settings; Type: TABLE; Schema: public; Owner: admin
---
-
-CREATE TABLE public.account_settings (
-    uuid uuid NOT NULL,
-    show_name boolean NOT NULL,
-    show_email boolean NOT NULL,
-    show_location boolean NOT NULL,
-    organizers_can_see boolean NOT NULL,
-    volunteers_can_see boolean NOT NULL,
-    initiative_map json NOT NULL,
-    password_reset_hash text,
-    password_reset_time timestamp without time zone,
-    verify_account_hash text,
-    cancel_registration_hash text
-);
-
-
-ALTER TABLE public.account_settings OWNER TO admin;
-
---
 -- Name: accounts; Type: TABLE; Schema: public; Owner: admin
 --
 
 CREATE TABLE public.accounts (
     uuid uuid NOT NULL,
-    email text NOT NULL,
-    username character varying(255) NOT NULL,
-    first_name character varying(255) NOT NULL,
+    username character varying(255),
+    first_name character varying(255),
     last_name character varying(255),
-    password text,
-    oauth character varying(32),
-    profile_pic text,
-    city character varying(32),
-    state character varying(32),
-    zip_code character varying(32),
-    roles character varying[] NOT NULL,
-    is_verified boolean NOT NULL
+    _primary_email_identifier_uuid uuid,
+    _primary_phone_number_identifier_uuid uuid
 );
 
 
 ALTER TABLE public.accounts OWNER TO admin;
+
+--
+-- Name: donation_emails; Type: TABLE; Schema: public; Owner: admin
+--
+
+CREATE TABLE public.donation_emails (
+    donation_uuid uuid NOT NULL,
+    email text,
+    request_sent_date timestamp without time zone
+);
+
+
+ALTER TABLE public.donation_emails OWNER TO admin;
 
 --
 -- Name: events; Type: TABLE; Schema: public; Owner: admin
@@ -188,10 +187,10 @@ ALTER TABLE public.initiatives OWNER TO admin;
 --
 
 CREATE TABLE public.notifications (
-    notification_uuid uuid NOT NULL,
+    uuid uuid NOT NULL,
     channel public.notificationchannel NOT NULL,
     recipient text NOT NULL,
-    subject text,
+    title text,
     message text NOT NULL,
     scheduled_send_date timestamp without time zone NOT NULL,
     status public.notificationstatus NOT NULL,
@@ -200,6 +199,37 @@ CREATE TABLE public.notifications (
 
 
 ALTER TABLE public.notifications OWNER TO admin;
+
+--
+-- Name: personal_identifiers; Type: TABLE; Schema: public; Owner: admin
+--
+
+CREATE TABLE public.personal_identifiers (
+    uuid uuid NOT NULL,
+    type public.identifiertype NOT NULL,
+    value text NOT NULL,
+    account_uuid uuid,
+    verified boolean NOT NULL,
+    slack_workspace_id text
+);
+
+
+ALTER TABLE public.personal_identifiers OWNER TO admin;
+
+--
+-- Name: verification_tokens; Type: TABLE; Schema: public; Owner: admin
+--
+
+CREATE TABLE public.verification_tokens (
+    uuid uuid NOT NULL,
+    created_at timestamp without time zone NOT NULL,
+    already_used boolean NOT NULL,
+    counter bigint NOT NULL,
+    personal_identifier_uuid uuid
+);
+
+
+ALTER TABLE public.verification_tokens OWNER TO admin;
 
 --
 -- Name: volunteer_openings; Type: TABLE; Schema: public; Owner: admin
@@ -232,39 +262,40 @@ CREATE TABLE public.volunteer_openings (
 ALTER TABLE public.volunteer_openings OWNER TO admin;
 
 --
--- Data for Name: account_settings; Type: TABLE DATA; Schema: public; Owner: admin
---
-
-COPY public.account_settings (uuid, show_name, show_email, show_location, organizers_can_see, volunteers_can_see, initiative_map, password_reset_hash, password_reset_time) FROM stdin;
-\.
-
-
---
 -- Data for Name: accounts; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.accounts (uuid, email, username, first_name, last_name, password, oauth, profile_pic, city, state, roles) FROM stdin;
+COPY public.accounts (uuid, username, first_name, last_name, _primary_email_identifier_uuid, _primary_phone_number_identifier_uuid) FROM stdin;
 \.
+
+
+--
+-- Data for Name: donation_emails; Type: TABLE DATA; Schema: public; Owner: admin
+--
+
+COPY public.donation_emails (donation_uuid, email, request_sent_date) FROM stdin;
+\.
+
 
 --
 -- Data for Name: events; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
 COPY public.events (id, airtable_last_modified, updated_at, is_deleted, uuid, event_name, event_graphics, signup_link, start, "end", description) FROM stdin;
-9795666069348	2021-03-02 18:44:42.954726	2021-03-05 18:44:42.954726	f	e60d7b04-a9e5-4bc3-917a-d89628947068	Rather different as paper sense.	{}	http://reed.com/	2021-03-12 18:44:42.954726	2021-03-16 18:44:42.954726	Bring agency than face reason no true garden. Somebody official after family site.
-0076436257394	2021-03-08 18:44:42.95551	2021-03-12 18:44:42.95551	f	82a69456-ea11-4186-b743-0514d9786ee6	Officer job environmental only dark stop.	{}	https://www.brown.com/categories/category/homepage.jsp	2021-03-19 18:44:42.95551	2021-03-21 18:44:42.95551	Thank approach voice yeah movement before. Size affect low give.
-9077627904074	2021-03-02 18:44:42.956161	2021-03-07 18:44:42.956161	f	14b1de7e-240b-4e35-ab63-8115fd8b7bfd	Example serve whose hear.	{}	https://coleman-reyes.com/	2021-03-14 18:44:42.956161	2021-03-22 18:44:42.956161	The cultural fire low thus late. Nation question occur source word guy.
-5146185244459	2021-03-05 18:44:42.956674	2021-03-09 18:44:42.956674	f	01975997-01d5-4742-a6ed-c1d0178b1304	Close walk who.	{}	http://www.allen.com/login/	2021-03-15 18:44:42.956674	2021-03-16 18:44:42.956674	He food describe improve. Follow between item official. South reduce for week across start.
-1862625240334	2021-03-03 18:44:42.95724	2021-03-08 18:44:42.95724	f	a45df793-553d-4527-978d-6bf5acdf12d4	Tonight herself home likely stage into.	{"{\\"url\\": \\"https://www.lorempixel.com/498/151\\"}"}	http://www.nash.com/main/	2021-03-14 18:44:42.95724	2021-03-18 18:44:42.95724	Force step public win government beautiful economy spend. Training over force science American natural travel. Maybe guy beat economy direction.
-8118871313838	2021-02-26 18:44:42.965278	2021-03-02 18:44:42.965278	f	ec95361a-7c14-4458-ba2c-3201333aedef	Physical along phone child economic arm.	{"{\\"url\\": \\"https://dummyimage.com/815x923\\"}"}	https://www.crawford.org/blog/tags/privacy/	2021-03-10 18:44:42.965278	2021-03-19 18:44:42.965278	Factor society time. Side laugh a impact.
-4273169487982	2021-02-22 18:44:42.965637	2021-02-25 18:44:42.965637	f	a21ea0c2-bedc-47e5-86ff-0bcb6e81976f	Your military society he another million.	{"{\\"url\\": \\"https://placekitten.com/113/404\\"}"}	http://thompson.net/about.php	2021-03-05 18:44:42.965637	2021-03-13 18:44:42.965637	Return model prevent free data tell address. Begin television authority oil.
-8135052026196	2021-03-02 18:44:42.966102	2021-03-08 18:44:42.966102	f	7071b824-4980-4cd9-a569-b6b855319796	Inside responsibility sound.	{}	https://www.wilson.info/faq.htm	2021-03-14 18:44:42.966102	2021-03-21 18:44:42.966102	Director spring then pay. Serious time right coach.
-7326305020493	2021-02-25 18:44:42.968999	2021-02-28 18:44:42.968999	f	1d4736bc-2114-402d-a608-72d1f8f0a230	Listen near eye degree law suddenly stop.	{"{\\"url\\": \\"https://placeimg.com/993/260/any\\"}"}	https://dodson-dodson.net/tag/main/privacy/	2021-03-08 18:44:42.968999	2021-03-12 18:44:42.968999	Record hit sign room. Live source then staff. Voice after hope could physical none. Buy western operation between although foot. Step scientist show green trade behavior.
-5681041905711	2021-02-18 18:44:42.969477	2021-02-20 18:44:42.969477	f	b8234d40-01a1-4e2c-a871-034c715d9039	Art chance resource alone.	{"{\\"url\\": \\"https://www.lorempixel.com/114/424\\"}"}	https://www.kim-west.com/	2021-02-28 18:44:42.969477	2021-03-04 18:44:42.969477	Go quickly light detail nice send. Arrive them miss commercial value step. Great fast brother issue run structure. Of make meet small whole choice. Career pass both plant several must remember over.
-8242114729190	2021-03-05 18:44:42.969913	2021-03-10 18:44:42.969913	f	eb6674d5-9033-409b-bcc2-786e3ef60c81	Season dog color point serious city kitchen.	{}	http://stokes-mills.com/	2021-03-16 18:44:42.969913	2021-03-20 18:44:42.969913	Arrive race Democrat husband article away office by. He be recently type parent. Lot company ground shake difference. Black site let. Ahead sport avoid industry participant.
-8117927086726	2021-03-06 18:44:42.972698	2021-03-11 18:44:42.972698	f	1d4736b5-d40f-4237-8f4c-f6c2e0020dfd	Word son great morning model ok court.	{"{\\"url\\": \\"https://placeimg.com/852/676/any\\"}"}	http://sullivan-evans.com/category/posts/faq/	2021-03-18 18:44:42.972698	2021-03-19 18:44:42.972698	Something same animal else shoulder third evening. Most buy environment important glass whole. Blue ten town little. Within either provide keep help woman.
-9881720466588	2021-03-05 18:44:42.973197	2021-03-07 18:44:42.973197	f	c32b61d3-d343-4183-b963-1e30380dcc47	Skin happy same send information will detail.	{"{\\"url\\": \\"https://placeimg.com/150/577/any\\"}"}	https://www.dean-ponce.com/	2021-03-15 18:44:42.973197	2021-03-25 18:44:42.973197	Stage whom leader design production according tax. Seat just world control. Parent question value push oil figure.
-4041284538489	2021-02-28 18:44:42.973595	2021-03-04 18:44:42.973595	f	3da9d443-dd09-4f3c-b007-18a0e7024b2b	Water head fire few actually.	{}	http://www.ballard-quinn.com/blog/wp-content/register.jsp	2021-03-12 18:44:42.973595	2021-03-16 18:44:42.973595	Place amount kind talk. Your often possible treat. Necessary discover tell husband.
+9181734156469	2021-04-03 23:32:40.41549	2021-04-06 23:32:40.41549	f	765ef0ea-975f-45b0-9090-d898ac36b763	Let open your name eat science away throughout.	{}	https://www.olson.com/login.htm	2021-04-13 23:32:40.41549	2021-04-17 23:32:40.41549	Mother since threat yeah if customer may. Ball fish land need standard interest cup.
+9133694445589	2021-04-09 23:32:40.416249	2021-04-13 23:32:40.416249	f	eb7a529d-6e71-49f8-b7b1-fe62ce903e20	Way on guess candidate walk goal.	{}	https://short.com/tags/blog/blog/homepage/	2021-04-20 23:32:40.416249	2021-04-22 23:32:40.416249	Adult age lead military morning race car fall. When fund themselves north new.
+2581979348006	2021-04-03 23:32:40.416702	2021-04-08 23:32:40.416702	f	06488894-74f2-4f80-ab70-b56bcd04bb35	Lawyer soldier number tough.	{}	https://mcdowell.info/blog/tag/list/author.php	2021-04-15 23:32:40.416702	2021-04-23 23:32:40.416702	Material most seven field art. Long along serious suggest thought. Company well window concern friend teacher body.
+1596770131338	2021-04-06 23:32:40.416943	2021-04-10 23:32:40.416943	f	4d9be9a1-3468-4add-a41e-f29fea9e5c9b	Wear whom fish mission assume home.	{}	http://erickson.biz/	2021-04-16 23:32:40.416943	2021-04-17 23:32:40.416943	Take state which day bill organization stage respond. Recently attack total rise.
+3504292223866	2021-04-04 23:32:40.417239	2021-04-09 23:32:40.417239	f	11b69a0f-82ac-4192-a92d-8b2b4fc96aa9	First pass specific treatment.	{"{\\"url\\": \\"https://placekitten.com/625/700\\"}"}	http://moore.com/explore/faq.asp	2021-04-15 23:32:40.417239	2021-04-19 23:32:40.417239	Us son least little able democratic. Cultural pass quality those reflect accept certainly measure. Under sure discuss main next activity. Article right up.
+4399040967623	2021-03-30 23:32:40.423314	2021-04-03 23:32:40.423314	f	7e8689a5-f16c-4640-8f4f-d8f3af6e0652	State one sign next my.	{"{\\"url\\": \\"https://dummyimage.com/999x119\\"}"}	https://jimenez-hughes.net/	2021-04-11 23:32:40.423314	2021-04-20 23:32:40.423314	Send will page start moment. Impact speech the over score available. Real check choose.
+5815602681619	2021-03-26 23:32:40.42362	2021-03-29 23:32:40.42362	f	b1e01c06-e944-46bf-8954-7d875bc41150	Responsibility boy responsibility forward consumer stage.	{"{\\"url\\": \\"https://www.lorempixel.com/338/247\\"}"}	https://fields-zimmerman.net/main.php	2021-04-06 23:32:40.42362	2021-04-14 23:32:40.42362	Skill couple would consider set method threat. School culture last work. Room though issue top military pull. Our since relationship and now.
+9935535402078	2021-04-03 23:32:40.423928	2021-04-09 23:32:40.423928	f	db76aa87-17ed-4956-af9a-2d554deec219	Mother trade station actually sign.	{}	https://fields.info/terms.php	2021-04-15 23:32:40.423928	2021-04-22 23:32:40.423928	Bank develop may should road consumer analysis. Something responsibility friend kind tax toward successful. Fall what lot onto north.
+6347556701017	2021-03-29 23:32:40.425924	2021-04-01 23:32:40.425924	f	ca5028f0-3345-452d-ac64-ff3eaf3f95ef	It campaign example increase argue.	{"{\\"url\\": \\"https://www.lorempixel.com/801/496\\"}"}	https://martinez.com/search/	2021-04-09 23:32:40.425924	2021-04-13 23:32:40.425924	Sea hospital let especially campaign quickly. Impact should them. Improve believe magazine as a around available.
+1588888179784	2021-03-22 23:32:40.426222	2021-03-24 23:32:40.426222	f	248f610f-e21c-41bf-882b-0ea82bd9d0fc	Firm pay nation situation onto.	{"{\\"url\\": \\"https://www.lorempixel.com/180/660\\"}"}	https://www.morales.com/search/tags/tag/terms.html	2021-04-01 23:32:40.426222	2021-04-05 23:32:40.426222	Forward even car force bring. Require cup case million hour must. Prove nation knowledge fall.
+7089376165035	2021-04-06 23:32:40.426676	2021-04-11 23:32:40.426676	f	05019869-de6d-4882-b3bd-ff1da189de79	Create half market.	{}	http://www.jackson-lopez.com/homepage.php	2021-04-17 23:32:40.426676	2021-04-21 23:32:40.426676	These small stand around. Involve bank hundred black sell as rate. Ago hold if Mr hair call seat.
+6705104007682	2021-04-07 23:32:40.428805	2021-04-12 23:32:40.428805	f	91dc8419-3bcb-47f4-ac5a-f80692a1ca08	Yard special sign compare provide trade.	{"{\\"url\\": \\"https://placeimg.com/166/607/any\\"}"}	https://www.todd-lewis.com/terms/	2021-04-19 23:32:40.428805	2021-04-20 23:32:40.428805	Military sign everything where table his machine. Live oil human dark put customer personal animal. Game service indeed picture about attention suddenly lose.
+5215914462768	2021-04-06 23:32:40.429143	2021-04-08 23:32:40.429143	f	20894885-bfae-4076-b607-79215f6a8c72	Able community raise situation yes nation.	{"{\\"url\\": \\"https://dummyimage.com/577x820\\"}"}	http://www.phillips.net/	2021-04-16 23:32:40.429143	2021-04-26 23:32:40.429143	Today describe support involve right. Clear kid agreement life very standard include between. Entire sure walk hand town game edge street.
+8246697447168	2021-04-01 23:32:40.429502	2021-04-05 23:32:40.429502	f	2b2fc679-9f14-4e61-8bfe-9610682bc85e	From theory interesting various.	{}	https://www.curry-garcia.com/index/	2021-04-13 23:32:40.429502	2021-04-17 23:32:40.429502	Baby of heart street. Mrs choose south hope price since. Stay hand character single local director civil.
 \.
 
 
@@ -273,9 +304,9 @@ COPY public.events (id, airtable_last_modified, updated_at, is_deleted, uuid, ev
 --
 
 COPY public.initiatives (id, airtable_last_modified, updated_at, is_deleted, uuid, initiative_name, "order", details_link, hero_image_urls, description, roles, events) FROM stdin;
-7694087271960	2021-02-23 18:44:42.966604	2021-02-28 18:44:42.966604	f	451ab264-262d-44f6-ab0d-e2b119f2bdd4	Danielle Thomas	1	http://www.white-chavez.com/	{"{\\"url\\": \\"https://placeimg.com/901/15/any\\"}"}	Camera system research personal personal here. Something finish receive study partner both field.	{6861749069949,8629011159341}	{8118871313838,4273169487982,8135052026196}
-6539241697181	2021-03-09 18:44:42.97032	2021-03-12 18:44:42.97032	f	41adc192-b75a-44d7-8690-6a84deb01300	Seth Pollard	2	http://evans.com/app/tags/list/search.htm	{"{\\"url\\": \\"https://placekitten.com/724/714\\"}"}	Matter short man mean detail. Street end represent whole century between eye good. One most only voice story.	{9718652962058,5888786203885}	{7326305020493,5681041905711,8242114729190}
-5192579170613	2021-02-27 18:44:42.974004	2021-03-03 18:44:42.974004	f	c7f42e7b-960c-4b52-8956-3e330550e5ee	Matthew Smith	3	https://www.wade-pearson.org/tags/login/	{}	Her single hot security. Nearly two among figure piece.	{8482888789772,6976112891741}	{8117927086726,9881720466588,4041284538489}
+0397370105740	2021-03-27 23:32:40.424212	2021-04-01 23:32:40.424212	f	0a472acc-6430-4c3b-ac31-b9b72b55cf90	Noah Williams	1	http://fleming.com/explore/main/tag/homepage.htm	{"{\\"url\\": \\"https://www.lorempixel.com/558/1004\\"}"}	Eight traditional break decide produce anything. Tv thought together yard sister voice plant. Authority view yeah according station.	{4826765665621,6286439111737}	{4399040967623,5815602681619,9935535402078}
+2822606960599	2021-04-10 23:32:40.426966	2021-04-13 23:32:40.426966	f	5ea19b96-d676-4ad9-896f-ab98ab0ac351	Eduardo Manning	2	http://www.alvarez.com/tags/category/search/	{"{\\"url\\": \\"https://www.lorempixel.com/725/880\\"}"}	Final spend each start put each drug. Forget system country know personal wife. Practice senior us rule. Option front must on.	{3089101928878,4245214338129}	{6347556701017,1588888179784,7089376165035}
+3235400700169	2021-03-31 23:32:40.429836	2021-04-04 23:32:40.429836	f	5858e172-776e-4f3e-b049-ad7aba7c35ee	Mary Arellano	3	http://nash.com/posts/app/tag/home.php	{}	Treat require everyone near ground dark suddenly. Listen statement not itself contain program.	{8584738251375,3541688610077}	{6705104007682,5215914462768,8246697447168}
 \.
 
 
@@ -283,7 +314,23 @@ COPY public.initiatives (id, airtable_last_modified, updated_at, is_deleted, uui
 -- Data for Name: notifications; Type: TABLE DATA; Schema: public; Owner: admin
 --
 
-COPY public.notifications (notification_uuid, channel, recipient, subject, message, scheduled_send_date, status, send_date) FROM stdin;
+COPY public.notifications (uuid, channel, recipient, title, message, scheduled_send_date, status, send_date) FROM stdin;
+\.
+
+
+--
+-- Data for Name: personal_identifiers; Type: TABLE DATA; Schema: public; Owner: admin
+--
+
+COPY public.personal_identifiers (uuid, type, value, account_uuid, verified, slack_workspace_id) FROM stdin;
+\.
+
+
+--
+-- Data for Name: verification_tokens; Type: TABLE DATA; Schema: public; Owner: admin
+--
+
+COPY public.verification_tokens (uuid, created_at, already_used, counter, personal_identifier_uuid) FROM stdin;
 \.
 
 
@@ -292,26 +339,18 @@ COPY public.notifications (notification_uuid, channel, recipient, subject, messa
 --
 
 COPY public.volunteer_openings (id, airtable_last_modified, updated_at, is_deleted, uuid, role_name, hero_image_urls, application_signup_form, more_info_link, priority, team, team_lead_ids, num_openings, minimum_time_commitment_per_week_hours, maximum_time_commitment_per_week_hours, job_overview, what_youll_learn, responsibilities_and_duties, qualifications, role_type) FROM stdin;
-3789843573991	2021-03-01 18:44:42.940183	2021-03-06 18:44:42.940183	f	faed777a-0fa1-4b5e-8505-4699bb5820e4	Boy their quickly happy here usually.	{"{\\"url\\": \\"https://dummyimage.com/346x275\\"}"}	http://barnes.com/category.jsp	http://huang-gentry.com/	MEDIUM	{2718121039455}	{}	6	2	8	Challenge entire have day source. Only mouth guess color leader hear out find. Stand drug teach do. Notice perform population wait many movement table. Congress if beyond son guy quickly as.	Reach finish know lawyer way day effort set. Lead including machine detail finish. Question stock picture sense pay commercial race.	Much letter job course. Senior show purpose news.	Quickly market some none. Drive back let place young. Cost south make seem glass east candidate positive.	REQUIRES_APPLICATION
-2121939418945	2021-02-22 18:44:42.942335	2021-02-25 18:44:42.942335	f	c69580fe-5c4a-4ddd-bf2e-653ddf4b1872	Hard page outside fall series risk the key.	{"{\\"url\\": \\"https://placekitten.com/869/186\\"}"}	http://www.brooks.com/search.php	http://www.jackson.com/category.asp	MEDIUM	{6234554738889}	{6751039497227}	6	8	4	Series seek adult better Mr able firm. Media view face arm war fly factor red. Add likely difficult arm require heavy.	Weight different discuss list while memory true. Forget mission mouth church piece whole. Science girl last. Yet sit certainly enter only any.	Picture give sure personal. Wide material four about number. Physical economy mention.	President early investment however blue rather all. Trouble computer us issue. Third industry option early. To trip owner fine back past international. Only media stage big early performance.	OPEN_TO_ALL
-8391000678507	2021-02-23 18:44:42.943569	2021-02-25 18:44:42.943569	f	cb7ebf91-51d8-4f60-b7ff-f55996c16229	Relationship professor draw.	{"{\\"url\\": \\"https://dummyimage.com/496x376\\"}"}	http://hale.net/index.html	https://www.campbell.com/categories/author.asp	MEDIUM	{9975241998021}	{}	3	8	7	Follow hotel bad yet. In apply hear listen. Spend special over care. Energy him create.	Heart matter guess. Study quickly model share heavy none piece.	Yet memory within. Middle forget pay already relationship mouth activity. Pick unit able home become page tonight back.	Responsibility today scientist. Window politics southern certain suffer now. South me ball chance over. Score relate and subject claim conference four sell.	REQUIRES_APPLICATION
-4519749187218	2021-03-04 18:44:42.945254	2021-03-08 18:44:42.945254	f	da1a0569-48db-45a3-b020-51f2315e6fc5	Town almost travel have against minute college.	{"{\\"url\\": \\"https://placekitten.com/949/40\\"}"}	http://www.mercado.com/home/	https://www.figueroa-owens.biz/	MEDIUM	{7162335465350}	{1974356976427}	2	5	3	Kind far another eight gun. Ok she feeling service after. Ability not enter.	Reflect financial authority beautiful defense throw dinner offer. Treatment what concern. Deal significant day. Without easy our account popular. Science ball bank purpose.	Whatever class high we. Remember design music particular. Coach despite truth camera simply store. Join like show for do middle television size.	Just than arrive social not learn development remain. Manager employee reality institution newspaper. Smile foreign near street three thank.	OPEN_TO_ALL
-7802722656724	2021-02-28 18:44:42.946582	2021-03-03 18:44:42.946582	f	304cfdb6-1ee9-4760-816c-c955366fcef7	Animal last own personal.	{"{\\"url\\": \\"https://placekitten.com/21/124\\"}"}	http://www.alvarado-anderson.net/search/terms/	http://lawrence.com/	MEDIUM	{3820308479295}	{}	5	9	9	Adult learn financial simple however space. Professional machine drug choice. Weight safe indicate prove share through can key.	Bit recently war perhaps final. Only key establish various class foreign laugh. Finish character instead list impact arm. Upon require focus small. Week worker firm ask try put.	Strong speech bill serve phone unit company. Mouth speech above think any well often. Become beat ball human here give possible capital. Almost join first answer. Professor personal else whole some people.	Physical contain media against add degree. Difference successful production age generation work. See compare enough name. Poor stand technology likely your office market blood.	REQUIRES_APPLICATION
-6861749069949	2021-02-28 18:44:42.963114	2021-03-04 18:44:42.963114	f	41a97395-8cfa-4815-946e-c26d3254acb7	Guy cultural usually.	{"{\\"url\\": \\"https://dummyimage.com/653x659\\"}"}	http://maxwell-brooks.org/	https://www.morris.com/terms/	MEDIUM	{0321621824883}	{1840260907393}	3	9	6	Partner citizen box itself effort learn. Especially market up boy feeling best during collection.	Book Democrat college. Exist understand authority Mrs dream product.	Few ready court item hundred catch. Car record up career. Fear piece this agency room. Kitchen treatment third main discussion. Participant company appear shake read policy area.	Set foreign analysis often peace toward. Camera election relate reflect tax different who. Executive only see religious. Program them court ball.	OPEN_TO_ALL
-8629011159341	2021-03-04 18:44:42.964267	2021-03-08 18:44:42.964267	f	63ad1538-8b64-4e96-80ed-4d27a43b92d8	Institution believe day.	{"{\\"url\\": \\"https://placekitten.com/234/241\\"}"}	https://torres.net/terms.html	https://cain.com/	MEDIUM	{2046077188423}	{}	2	4	4	Ever like high several site. Value now certain century staff make. Southern knowledge health movement cultural play those.	Site city down. Throughout space while blue. Exactly however result.	Community appear animal scientist. General right risk investment. Join eye three room several. Low career idea range treat individual. Million off attorney tough company.	Eye ahead build show arrive generation. Available beautiful television fill PM example into. Somebody foot paper population.	OPEN_TO_ALL
-9718652962058	2021-02-20 18:44:42.967331	2021-02-25 18:44:42.967331	f	1af1ee8d-2d5f-4762-837b-1c707bab8eb7	Him really walk loss.	{"{\\"url\\": \\"https://dummyimage.com/525x205\\"}"}	https://steele-choi.biz/main/register.htm	https://gibson.org/wp-content/posts/post/	MEDIUM	{9932248566929}	{2980888233296}	3	9	5	Light class pressure. How loss easy again. Coach late about old.	Prepare agreement guy billion certainly practice. Agency bill series certain mother us. Military quickly opportunity Mrs.	Plant because part economy. Own center develop customer majority clearly. That pretty firm make threat. Light religious toward scientist arrive.	Guess baby citizen focus night personal than. Practice once continue prepare job. Sense believe increase.	REQUIRES_APPLICATION
-5888786203885	2021-02-21 18:44:42.968146	2021-02-24 18:44:42.968146	f	5a089f6b-7f93-483e-8505-ecba54c0ac40	American type international upon campaign someone court.	{"{\\"url\\": \\"https://placekitten.com/693/564\\"}"}	http://hicks-glass.com/	https://www.harris-cox.org/search/blog/search.php	MEDIUM	{9395828032083}	{4413681294020}	3	3	6	Rule manage these suggest forget page community. Into ahead deal second town wind. Threat person treatment every inside your.	Statement lead land box. Analysis room forget miss. American shoulder family truth one.	We current first relate once. Relate general hold tend almost. Enjoy recently suffer too. Start or what build kitchen statement. Build bag bag.	Amount condition many. Need next hot focus.	REQUIRES_APPLICATION
-8482888789772	2021-03-09 18:44:42.970948	2021-03-12 18:44:42.970948	f	6bb8630c-125a-4b78-8607-ce2a058345d7	Language gun strategy way choice identify.	{"{\\"url\\": \\"https://placeimg.com/137/711/any\\"}"}	https://lam.com/	https://franklin.com/home.htm	MEDIUM	{2670047923242}	{}	2	8	5	Statement several year more little star teach. News decision especially manager former listen yeah.	Century former small never action serious. Actually executive hand likely. Break share act win identify market. Wrong establish by now.	American war challenge matter. Much turn develop.	Leader economic billion key. Need material way sort attorney local subject. Market indeed wait floor soon miss. Spend simply return position determine south. Dark talk phone.	REQUIRES_APPLICATION
-6976112891741	2021-02-21 18:44:42.971768	2021-02-25 18:44:42.971768	f	15e0ce96-ace7-483e-90c9-5dc64d5d95e6	Attention network believe nothing guess occur.	{}	https://www.beck.info/	http://west-garcia.com/tags/privacy/	MEDIUM	{1737251692591}	{9580274498686}	6	4	6	Beat despite traditional performance gas lead. Member article series describe mother. Human method different hair discover line.	Always production wish book eat card never will. Itself trouble letter rule live. International international most close former condition. Sense at kitchen many degree.	May address bank civil indeed trade remember event. Whatever here reveal challenge property by range. Score ever dog can pull effect. Perhaps TV ever himself health. Upon old red create try.	Five car health conference serve. Economic particularly interesting material prepare wide drop inside.	REQUIRES_APPLICATION
+6753523204564	2021-04-02 23:32:40.40516	2021-04-07 23:32:40.40516	f	f6108601-c08a-4f21-9f81-1168b2027acf	Degree attention bag over.	{"{\\"url\\": \\"https://www.lorempixel.com/381/862\\"}"}	https://johnson.com/terms.htm	https://gilbert.com/categories/tags/login/	MEDIUM	{8725400549875}	{}	6	2	8	Seem use involve news. Report risk writer growth class shoulder ahead general. Ten father professor mouth visit state artist.	Discuss report half stock dark pick. Cultural will laugh box guess country leader media. Human thought remember strategy time.	Audience by second likely purpose since. Task face can. Direction couple step wait on. Half how size general. Character war large eye.	Ask do occur form matter test. Red blue choice ok. Management camera body decision.	REQUIRES_APPLICATION
+3780349975791	2021-03-26 23:32:40.406024	2021-03-29 23:32:40.406024	f	c9b16171-e712-4995-8f3d-cefc1f833952	Sense guy need candidate.	{"{\\"url\\": \\"https://dummyimage.com/795x587\\"}"}	https://www.price-hayden.com/wp-content/wp-content/explore/search.html	http://www.smith.com/	MEDIUM	{9389107162714}	{3532321164606}	6	8	4	Finally term capital during one. Race floor wear member nature cell rock. Better and conference million. Investment peace on home year during coach. Expect move center both enough director.	Bring poor by sound name common. Want foreign reason fast which. Instead production hit morning low short tree him. Identify skill couple base inside pretty difficult study. Tough above important or exactly deep through.	Thus wait finish during our smile. Player popular deep baby. Professional they success eight. Be team wait rock color.	Truth fish paper great. Face likely amount former happen your daughter. Important despite act recently hold type TV. Red score mention step mention include would.	OPEN_TO_ALL
+9006898382939	2021-03-27 23:32:40.40686	2021-03-29 23:32:40.40686	f	2b52707b-c84e-4dee-ad7c-1dae4d1b96f0	Ball himself beautiful brother word respond lead interesting.	{"{\\"url\\": \\"https://placekitten.com/462/550\\"}"}	https://hogan.biz/app/faq.htm	http://yoder.net/home.jsp	MEDIUM	{2370183504663}	{}	3	8	7	Window beautiful thank need stop onto partner. Set nation general.	Will more western bank here easy. Of mission participant. Prove law hand result. Everyone price church sit win after certainly. Mission threat government remember idea.	Bill state might main. Perhaps late economic put bank. Sell teach beautiful side organization.	Environmental experience mouth instead tree letter operation. Loss trade leg seven. Fast join tonight blue remember college past. Sing throw prevent writer see set administration.	REQUIRES_APPLICATION
+0609833533626	2021-04-05 23:32:40.407609	2021-04-09 23:32:40.407609	f	848e8854-64a5-455f-a903-ff575472ba9b	Together professor almost impact central thousand teach somebody.	{"{\\"url\\": \\"https://dummyimage.com/331x283\\"}"}	https://morrison.com/register/	https://www.rios.info/search/	MEDIUM	{9371874618594}	{7276105513803}	2	5	3	Arm skin interest organization away ago teach. Approach information write good data forget sign. He business arm should call face wife phone.	Top adult rule forward. Air sport right five figure capital.	Church lawyer argue who such key million. Day upon either better. That form true decision meeting. Prepare about goal say ball music drug east.	Fight office organization month without. Rate work thought yet. Garden prevent manager such play even. Determine against wide gun return majority prove. Our them determine total money.	OPEN_TO_ALL
+6217013592956	2021-04-01 23:32:40.408163	2021-04-04 23:32:40.408163	f	4e1a1e64-33a4-4bca-a5cf-420146ec19b6	Pressure soldier each there good.	{"{\\"url\\": \\"https://placekitten.com/791/909\\"}"}	https://wilson.com/explore/app/wp-content/homepage.html	https://eaton.com/categories/faq/	MEDIUM	{4464737391231}	{}	5	9	9	Later mouth mean. Impact character along.	Pattern together ok resource. Measure trade team treat boy hand memory. Us himself investment brother student low foreign much. She same score like.	Group partner job audience. Never surface west law manager though. Bar less store note same. Agent site none little imagine state official.	Mission then blood white site situation down. Address PM property ago commercial which not. Society hand phone radio bag suggest last.	REQUIRES_APPLICATION
+4826765665621	2021-04-01 23:32:40.421698	2021-04-05 23:32:40.421698	f	a909a1d1-b1fc-4b3b-bed7-c32907795222	Traditional man collection special type clearly between.	{"{\\"url\\": \\"https://placekitten.com/799/423\\"}"}	https://hernandez.com/	http://lopez-pope.biz/	MEDIUM	{8960643281254}	{1231520782520}	3	9	6	Computer conference result. Trial admit me single yes conference contain there. Money red goal begin he professor range. She walk mind black. Candidate on everything bit reveal who anyone language.	It hear attention white. Visit poor front.	Too about budget mouth this commercial two. Consumer card general marriage less whose agreement.	Want brother important remember data receive. Sometimes picture security training big. Form if forward career. Better environmental region business others consider.	OPEN_TO_ALL
+6286439111737	2021-04-05 23:32:40.422563	2021-04-09 23:32:40.422563	f	5b473aa8-db81-4ebe-9d2e-b8146229e446	Major relate name contain.	{"{\\"url\\": \\"https://dummyimage.com/787x147\\"}"}	https://www.davis.com/	https://www.hammond-hurley.com/tag/register/	MEDIUM	{8346826433793}	{}	2	4	4	Tend decision of couple country chance find. Action data fight. Support billion soldier cover. West executive skill commercial.	Hair form notice upon suddenly. Fine good rule foreign or point. Population fish these anything.	Marriage brother partner rest represent. Eight decide chair development challenge. Compare particular against on note successful pressure.	Practice guy laugh the whether miss camera. Movie head last early long. Character ball garden indicate pattern. Agreement defense firm ability he budget.	OPEN_TO_ALL
+3089101928878	2021-03-24 23:32:40.424585	2021-03-29 23:32:40.424585	f	418bdde9-8132-4a47-b4eb-84c157852c68	Party actually movie knowledge particular whom.	{"{\\"url\\": \\"https://placeimg.com/750/831/any\\"}"}	https://www.boyd.info/category/search/search/login.htm	http://www.diaz-reyes.org/faq.html	MEDIUM	{4761654764644}	{0286775226917}	3	9	5	Tv score direction down else. Back low Mr. Central follow system will. Resource word open let director care some.	Institution black require those imagine after. Smile case should choose kind how party.	Difficult manage future. Stand unit learn avoid onto. Unit whose official door before station surface.	Education away perhaps mother. And someone pull college teach report ability. Job piece ago foot world. Set baby similar. Old because quickly.	REQUIRES_APPLICATION
+4245214338129	2021-03-25 23:32:40.425323	2021-03-28 23:32:40.425323	f	a53a6481-5567-4c9b-b2a7-7d19d64b9dce	Spend myself behavior property.	{"{\\"url\\": \\"https://placekitten.com/156/231\\"}"}	https://www.lawson.com/tags/index.php	http://www.dunn.com/tags/posts/list/search/	MEDIUM	{0696447362483}	{4959417060328}	3	3	6	Thought few assume show rate candidate. Region main land agency laugh on draw. Chance right country often very Democrat. Degree back source various work full you chance. Step a consumer politics reality capital none remember.	Pattern perform never. Star hour white outside yet own general red. Allow newspaper recently operation discussion.	Item some yeah. Card walk tonight important hand discover choose consumer. Agent hope air contain.	Across learn some on. Top agree listen section. American PM blue various. Discussion today whom hair include activity man wait.	REQUIRES_APPLICATION
+8584738251375	2021-04-10 23:32:40.427514	2021-04-13 23:32:40.427514	f	2bf3e55f-93ad-4138-b982-3b0fa1807546	Artist main sure itself strategy with.	{"{\\"url\\": \\"https://placekitten.com/836/200\\"}"}	https://www.davidson.org/posts/main/categories/author/	http://andrews-thompson.info/home/	MEDIUM	{3733355392946}	{}	2	8	5	Short already Mrs raise floor. Ground claim admit cup several guy rule street. Lose ok table several tonight. Forward field maintain table. Change information exactly crime send.	Trial smile sister know baby two fine her. Republican state budget. Better friend fact pretty resource peace maintain. Figure general officer treatment account.	Crime Congress sing may. Energy successful land. Success source white. Indeed building citizen yet good.	Once group feel seek. Population land realize despite. Difficult no dream travel method.	REQUIRES_APPLICATION
+3541688610077	2021-03-25 23:32:40.428149	2021-03-29 23:32:40.428149	f	65e09669-f1d6-4720-836c-aadaa40af24a	Indeed would character well energy.	{}	http://terrell-rodriguez.net/main/search/	http://www.sanchez.com/tags/explore/list/author.asp	MEDIUM	{4246232485420}	{9084155520089}	6	4	6	Billion among by. Sense use with line lose item camera.	Keep serious skin job deal. General any chair discuss child particular specific. Job leg least record base do project seem.	Allow foreign pull sound themselves majority why. Number some fly stuff bank difficult five. Entire thing tree step structure sure cold. Present feeling very.	Radio light much total money even spring. Trip teacher blue structure oil. Organization lawyer say not human south store. With court region career.	REQUIRES_APPLICATION
 \.
-
-
---
--- Name: account_settings account_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
---
-
-ALTER TABLE ONLY public.account_settings
-    ADD CONSTRAINT account_settings_pkey PRIMARY KEY (uuid);
 
 
 --
@@ -320,6 +359,15 @@ ALTER TABLE ONLY public.account_settings
 
 ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: donation_emails donation_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.donation_emails
+    ADD CONSTRAINT donation_emails_pkey PRIMARY KEY (donation_uuid);
+
 
 --
 -- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
@@ -342,7 +390,23 @@ ALTER TABLE ONLY public.initiatives
 --
 
 ALTER TABLE ONLY public.notifications
-    ADD CONSTRAINT notifications_pkey PRIMARY KEY (notification_uuid);
+    ADD CONSTRAINT notifications_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: personal_identifiers personal_identifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.personal_identifiers
+    ADD CONSTRAINT personal_identifiers_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: verification_tokens verification_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.verification_tokens
+    ADD CONSTRAINT verification_tokens_pkey PRIMARY KEY (uuid);
 
 
 --
@@ -354,17 +418,35 @@ ALTER TABLE ONLY public.volunteer_openings
 
 
 --
--- Name: ix_accounts_email; Type: INDEX; Schema: public; Owner: admin
+-- Name: accounts accounts__primary_email_identifier_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
 --
 
-CREATE UNIQUE INDEX ix_accounts_email ON public.accounts USING btree (email);
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts__primary_email_identifier_uuid_fkey FOREIGN KEY (_primary_email_identifier_uuid) REFERENCES public.personal_identifiers(uuid);
 
 
 --
--- Name: ix_accounts_username; Type: INDEX; Schema: public; Owner: admin
+-- Name: accounts accounts__primary_phone_number_identifier_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
 --
 
-CREATE UNIQUE INDEX ix_accounts_username ON public.accounts USING btree (username);
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts__primary_phone_number_identifier_uuid_fkey FOREIGN KEY (_primary_phone_number_identifier_uuid) REFERENCES public.personal_identifiers(uuid);
+
+
+--
+-- Name: personal_identifiers personal_identifiers_account_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.personal_identifiers
+    ADD CONSTRAINT personal_identifiers_account_uuid_fkey FOREIGN KEY (account_uuid) REFERENCES public.accounts(uuid);
+
+
+--
+-- Name: verification_tokens verification_tokens_personal_identifier_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.verification_tokens
+    ADD CONSTRAINT verification_tokens_personal_identifier_uuid_fkey FOREIGN KEY (personal_identifier_uuid) REFERENCES public.personal_identifiers(uuid);
 
 
 --

--- a/db/data/test/data.test.sql
+++ b/db/data/test/data.test.sql
@@ -46,7 +46,8 @@ CREATE TYPE public.identifiertype AS ENUM (
     'EMAIL',
     'PHONE',
     'SLACK_ID',
-    'GOOGLE_ID'
+    'GOOGLE_ID',
+    'GITHUB_ID'
 );
 
 
@@ -111,27 +112,12 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
--- Name: accounts; Type: TABLE; Schema: public; Owner: admin
---
-
-CREATE TABLE public.accounts (
-    uuid uuid NOT NULL,
-    username character varying(255),
-    first_name character varying(255),
-    last_name character varying(255),
-    _primary_email_identifier_uuid uuid,
-    _primary_phone_number_identifier_uuid uuid
-);
-
-
-ALTER TABLE public.accounts OWNER TO admin;
-
---
--- Name: donation_emails; Type: TABLE; Schema: public; Owner: admin
+-- Name: account_settings; Type: TABLE; Schema: public; Owner: admin
 --
 
 CREATE TABLE public.account_settings (
     uuid uuid NOT NULL,
+    account_uuid uuid,
     show_name boolean NOT NULL,
     show_email boolean NOT NULL,
     show_location boolean NOT NULL,
@@ -139,9 +125,7 @@ CREATE TABLE public.account_settings (
     volunteers_can_see boolean NOT NULL,
     initiative_map json NOT NULL,
     password_reset_hash text,
-    password_reset_time timestamp without time zone,
-    verify_account_hash text,
-    cancel_registration_hash text
+    password_reset_time timestamp without time zone
 );
 
 
@@ -153,18 +137,17 @@ ALTER TABLE public.account_settings OWNER TO admin;
 
 CREATE TABLE public.accounts (
     uuid uuid NOT NULL,
-    email text NOT NULL,
-    username character varying(255) NOT NULL,
+    username character varying(255),
     first_name character varying(255),
     last_name character varying(255),
     password text,
-    oauth character varying(32),
     profile_pic text,
     city character varying(32),
     state character varying(32),
-    zip_code character varying(32),
     roles character varying[] NOT NULL,
-    is_verified boolean NOT NULL
+    zip_code character varying(32),
+    _primary_email_identifier_uuid uuid,
+    _primary_phone_number_identifier_uuid uuid
 );
 
 
@@ -293,15 +276,7 @@ CREATE TABLE public.volunteer_openings (
 ALTER TABLE public.volunteer_openings OWNER TO admin;
 
 --
--- Name: accounts accounts_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
---
-
-ALTER TABLE ONLY public.accounts
-    ADD CONSTRAINT accounts_pkey PRIMARY KEY (uuid);
-
-
---
--- Name: donation_emails donation_emails_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
+-- Name: account_settings account_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
 ALTER TABLE ONLY public.account_settings
@@ -315,12 +290,37 @@ ALTER TABLE ONLY public.account_settings
 ALTER TABLE ONLY public.accounts
     ADD CONSTRAINT accounts_pkey PRIMARY KEY (uuid);
 
+
+--
+-- Name: accounts accounts_username_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.accounts
+    ADD CONSTRAINT accounts_username_key UNIQUE (username);
+
+
+--
+-- Name: events events_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.events
+    ADD CONSTRAINT events_id_key UNIQUE (id);
+
+
 --
 -- Name: events events_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
 ALTER TABLE ONLY public.events
     ADD CONSTRAINT events_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: initiatives initiatives_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.initiatives
+    ADD CONSTRAINT initiatives_id_key UNIQUE (id);
 
 
 --
@@ -348,6 +348,14 @@ ALTER TABLE ONLY public.personal_identifiers
 
 
 --
+-- Name: personal_identifiers personal_identifiers_type_value_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.personal_identifiers
+    ADD CONSTRAINT personal_identifiers_type_value_key UNIQUE (type, value);
+
+
+--
 -- Name: verification_tokens verification_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
@@ -356,11 +364,55 @@ ALTER TABLE ONLY public.verification_tokens
 
 
 --
+-- Name: volunteer_openings volunteer_openings_id_key; Type: CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.volunteer_openings
+    ADD CONSTRAINT volunteer_openings_id_key UNIQUE (id);
+
+
+--
 -- Name: volunteer_openings volunteer_openings_pkey; Type: CONSTRAINT; Schema: public; Owner: admin
 --
 
 ALTER TABLE ONLY public.volunteer_openings
     ADD CONSTRAINT volunteer_openings_pkey PRIMARY KEY (uuid);
+
+
+--
+-- Name: ix_account_uuid; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_account_uuid ON public.personal_identifiers USING hash (account_uuid);
+
+
+--
+-- Name: ix_event_id; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_event_id ON public.events USING hash (id);
+
+
+--
+-- Name: ix_role_id; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_role_id ON public.volunteer_openings USING hash (id);
+
+
+--
+-- Name: ix_value; Type: INDEX; Schema: public; Owner: admin
+--
+
+CREATE INDEX ix_value ON public.personal_identifiers USING hash (value);
+
+
+--
+-- Name: account_settings account_settings_account_uuid_fkey; Type: FK CONSTRAINT; Schema: public; Owner: admin
+--
+
+ALTER TABLE ONLY public.account_settings
+    ADD CONSTRAINT account_settings_account_uuid_fkey FOREIGN KEY (account_uuid) REFERENCES public.accounts(uuid);
 
 
 --
@@ -398,3 +450,4 @@ ALTER TABLE ONLY public.verification_tokens
 --
 -- PostgreSQL database dump complete
 --
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -8,4 +8,5 @@ services:
   api:
     environment:
       ENV: test
+      JUPYTER_TOKEN: easy
       GOOGLE_APPLICATION_CREDENTIALS: ./gcp_credentials.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,11 +3,14 @@ version: "3.7"
 services:
   api:
     build: ./api
-    command: uvicorn --host 0.0.0.0 api:app --app-dir . --port 8081 --reload
+    command: bash -c "jupyter notebook --port 8889 --ip 0.0.0.0 --allow-root --NotebookApp.token='easy' & uvicorn --host 0.0.0.0 api:app --app-dir . --port 8081 --reload"
+    environment:
+      JUPYTER_TOKEN: easy
     depends_on:
       db:
         condition: service_healthy
     ports:
+    - 8889:8889
     - 8081:8081
     volumes:
     - ./api:/api


### PR DESCRIPTION
Tripps Changes:
  * Adds PersonalIdentifiers to capture sensitive, unique IDs
  * Adds VerificationTokens to handle identifier verification lifecycle
  * Adds APIs for beginning and finishing identifier verification
  * Email verification emails triggered automatically upon registration
  *  Support for account and non-account registrations
  * Tests and various improvements

Integrating with existing things:
  * Tried to keep as many of the api routes and schemas the same
  * Added some db relationships such as "email" to pull the email from an identifier to mimic the old email column behavior
  * removed hash verification in favor of Tripps code that was already set up with the personal identifiers
  * modified the personal identifiers verification to work for the account-less subscription flow (coming soon)
  * Added some "cascade" specifiers to clean up account_settings, identifiers, and verification tokens when accounts are deleted
  * Added some Hash-based indexes to some tables to make lookups fast and efficient